### PR TITLE
Browser History URLs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="favicon.ico" />
+    <link rel="icon" href="/assets/favicon.ico" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
@@ -10,21 +10,43 @@
       content="Let&#39;s build decentralized experiences"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@NearSocial_">
-    <meta name="twitter:image" content="https://storage.googleapis.com/alpha-near-images/alpha-social-cover.jpg">
-    <meta property="og:image" content="https://storage.googleapis.com/alpha-near-images/alpha-social-cover.jpg">
-    <meta property="og:type" content="website">
+    <meta name="twitter:site" content="@NearSocial_" />
+    <meta
+      name="twitter:image"
+      content="https://storage.googleapis.com/alpha-near-images/alpha-social-cover.jpg"
+    />
+    <meta
+      property="og:image"
+      content="https://storage.googleapis.com/alpha-near-images/alpha-social-cover.jpg"
+    />
+    <meta property="og:type" content="website" />
     <meta property="og:title" content="NEAR" />
-    <meta property="og:description" content="Let&#39;s build decentralized experiences" />
-    <link rel="apple-touch-icon" href="logo192.png" />
+    <meta
+      property="og:description"
+      content="Let&#39;s build decentralized experiences"
+    />
+    <link rel="apple-touch-icon" href="/assets/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <title>NEAR</title>
-    <script defer data-domain="near.social" src="https://plausible.io/js/script.hash.js"></script>
-    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }; window.analytics = function() { window.plausible(...arguments) }</script>
+    <script
+      defer
+      data-domain="near.social"
+      src="https://plausible.io/js/script.hash.js"
+    ></script>
+    <script>
+      window.plausible =
+        window.plausible ||
+        function () {
+          (window.plausible.q = window.plausible.q || []).push(arguments);
+        };
+      window.analytics = function () {
+        window.plausible(...arguments);
+      };
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import "@near-wallet-selector/modal-ui/styles.css";
 import "bootstrap/dist/js/bootstrap.bundle";
 import "App.scss";
-import { HashRouter as Router, Link, Route, Switch } from "react-router-dom";
+import { BrowserRouter, Route, Switch } from "react-router-dom";
 import EditorPage from "./pages/EditorPage";
 import ViewPage from "./pages/ViewPage";
 import { setupWalletSelector } from "@near-wallet-selector/core";
@@ -90,16 +90,6 @@ function App(props) {
   }, [initNear]);
 
   useEffect(() => {
-    if (
-      !location.search.includes("?account_id") &&
-      !location.search.includes("&account_id") &&
-      (location.search || location.href.includes("/?#"))
-    ) {
-      window.history.replaceState({}, "/", "/" + location.hash);
-    }
-  }, [location]);
-
-  useEffect(() => {
     if (!near) {
       return;
     }
@@ -179,7 +169,7 @@ function App(props) {
         <script src="https://unpkg.com/@phosphor-icons/web@2.0.3"></script>
       </Helmet>
 
-      <Router basename={process.env.PUBLIC_URL}>
+      <BrowserRouter basename={process.env.PUBLIC_URL}>
         <Switch>
           <Route path={"/embed/:widgetSrc*"}>
             <EmbedPage {...passProps} />
@@ -193,7 +183,7 @@ function App(props) {
             <ViewPage {...passProps} />
           </Route>
         </Switch>
-      </Router>
+      </BrowserRouter>
     </StyledApp>
   );
 }

--- a/src/hooks/useHashUrlBackwardsCompatibility.js
+++ b/src/hooks/useHashUrlBackwardsCompatibility.js
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useHistory } from "react-router-dom";
+
+export function useHashUrlBackwardsCompatibility() {
+  const history = useHistory();
+
+  function onHashChange(event) {
+    const url = event.newURL.split("#").pop() ?? "/";
+    history.replace(url);
+  }
+
+  useEffect(() => {
+    window.addEventListener("hashchange", onHashChange);
+
+    return () => {
+      window.removeEventListener("hashchange", onHashChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (window.location.hash) {
+      const url = window.location.href.split("#").pop() ?? "/";
+      history.replace(url);
+    }
+  }, []);
+}

--- a/src/hooks/useHashUrlBackwardsCompatibility.js
+++ b/src/hooks/useHashUrlBackwardsCompatibility.js
@@ -6,7 +6,10 @@ export function useHashUrlBackwardsCompatibility() {
 
   function onHashChange(event) {
     const url = event.newURL.split("#").pop() ?? "/";
-    history.replace(url);
+
+    if (url[0] === "/") {
+      history.replace(url);
+    }
   }
 
   useEffect(() => {
@@ -20,7 +23,10 @@ export function useHashUrlBackwardsCompatibility() {
   useEffect(() => {
     if (window.location.hash) {
       const url = window.location.href.split("#").pop() ?? "/";
-      history.replace(url);
+
+      if (url[0] === "/") {
+        history.replace(url);
+      }
     }
   }, []);
 }

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -19,6 +19,7 @@ import CreateModal from "../components/Editor/CreateModal";
 import { SaveDraftModal } from "../components/SaveDraft";
 import styled from "styled-components";
 import VsCodeBanner from "../components/Editor/VsCodeBanner";
+import { useHashUrlBackwardsCompatibility } from "../hooks/useHashUrlBackwardsCompatibility";
 
 const TopMenu = styled.div`
   border-radius: 0.375rem;
@@ -131,6 +132,8 @@ export default function EditorPage(props) {
   const [layout, setLayoutState] = useState(
     ls.get(EditorLayoutKey) || Layout.Tabs
   );
+
+  useHashUrlBackwardsCompatibility();
 
   const setLayout = useCallback(
     (layout) => {
@@ -550,7 +553,7 @@ export default function EditorPage(props) {
     if (!near || !files) {
       return;
     }
-    if (widgetSrc) {
+    if (widgetSrc && !window.location.hash) {
       if (widgetSrc === "new") {
         createFile(Filetype.Widget);
       } else {

--- a/src/pages/EmbedPage.js
+++ b/src/pages/EmbedPage.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Widget } from "near-social-vm";
 import { useParams } from "react-router-dom";
 import { useQuery } from "../hooks/useQuery";
+import { useHashUrlBackwardsCompatibility } from "../hooks/useHashUrlBackwardsCompatibility";
 
 export default function EmbedPage(props) {
   const { widgetSrc } = useParams();
@@ -9,6 +10,8 @@ export default function EmbedPage(props) {
   const [widgetProps, setWidgetProps] = useState({});
 
   const src = widgetSrc || props.widgets.default;
+
+  useHashUrlBackwardsCompatibility();
 
   useEffect(() => {
     setWidgetProps(

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Widget } from "near-social-vm";
 import { useParams } from "react-router-dom";
 import { useQuery } from "../hooks/useQuery";
+import { useHashUrlBackwardsCompatibility } from "../hooks/useHashUrlBackwardsCompatibility";
 
 export default function ViewPage(props) {
   const { widgetSrc } = useParams();
@@ -11,6 +12,8 @@ export default function ViewPage(props) {
   const src = widgetSrc || props.widgets.default;
   const setWidgetSrc = props.setWidgetSrc;
   const viewSourceWidget = props.widgets.viewSource;
+
+  useHashUrlBackwardsCompatibility();
 
   useEffect(() => {
     setWidgetProps(Object.fromEntries([...query.entries()]));

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,8 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [
+    {
+      "source": "/((?!.js|.css|.png|.jpg|.jpeg|.svg|.webp|.woff2|.json|.html).*)",
+      "destination": "/"
+    }
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,9 @@ module.exports = function (env) {
         publicPath: "/",
       },
       devServer: {
-        historyApiFallback: true,
+        historyApiFallback: {
+          disableDotRule: true,
+        },
       },
       module: {
         rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = function (env) {
           template: `${paths.publicPath}/index.html`,
           favicon: `${paths.publicPath}/favicon.png`,
           robots: `${paths.publicPath}/robots.txt`,
+          publicPath: "/",
         }),
         new webpack.ProgressPlugin(),
         new webpack.ProvidePlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,9 @@ module.exports = function (env) {
         filename: "[name].bundle.js",
         publicPath: "/",
       },
+      devServer: {
+        historyApiFallback: true,
+      },
       module: {
         rules: [
           {


### PR DESCRIPTION
Adding support for browser history URLs (`/adminalpha.near/widget/...`) while remaining backwards compatible with hash urls (`/#/adminalpha.near/widget/...`).

https://near-discovery-git-feat-browser-h-3c793a-near-developer-console.vercel.app/adminalpha.near/widget/NearOrg.HomePage

https://near-discovery-git-feat-browser-h-3c793a-near-developer-console.vercel.app/#/adminalpha.near/widget/NearOrg.HomePage

This serves two purposes:

- Better SEO support as Google ignores everything after the `#`
- Prettier URLs
- Support element ID anchor scroll: `<a href="#my-html-id">Scroll to element</a>`

Everything appears to be working locally after testing. Will test more on preview URL.

**NOTE: The additions in `vercel.json` are a necessary hack until we switch to Next due to the confusion between file extension URLs and URLs like `/adminalpha.near/widget/NearOrg.HomePage`.** 