### PR TITLE
Upgrade to VM 1.2.0 for iframe resizer support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "error-polyfill": "^0.1.2",
     "local-storage": "^2.0.0",
     "near-api-js": "^0.45.1",
-    "near-social-vm": "NearSocial/VM#1.1.0",
+    "near-social-vm": "NearSocial/VM#1.2.0",
     "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5157,6 +5157,19 @@ ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+iframe-resizer-react@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/iframe-resizer-react/-/iframe-resizer-react-1.1.0.tgz#5009e019b7a5c7f1c009bff5bcdf0dbf33557465"
+  integrity sha512-FrytSq91AIJaDgE+6uK/Vdd6IR8CrwLoZ6eGmL2qQMPTzF0xlSV2jaSzRRUh5V2fttD7vzl21jvBl97bV40eBw==
+  dependencies:
+    iframe-resizer "^4.3.0"
+    warning "^4.0.3"
+
+iframe-resizer@^4.3.0:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.6.tgz#61d92c1adefe5d416bff4fbf80c7f1f74be70ec0"
+  integrity sha512-wz0WodRIF6eP0oGQa5NIP1yrITAZ59ZJvVaVJqJRjaeCtfm461vy2C3us6CKx0e7pooqpIGLpVMSTzrfAjX9Sg==
+
 ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
@@ -6520,9 +6533,9 @@ near-seed-phrase@^0.2.0:
     near-hd-key "^1.2.1"
     tweetnacl "^1.0.2"
 
-near-social-vm@NearSocial/VM#1.1.0:
-  version "1.1.0"
-  resolved "https://codeload.github.com/NearSocial/VM/tar.gz/7d434ab6cf8e3f80b08a3e429429a860799c11d9"
+near-social-vm@NearSocial/VM#1.2.0:
+  version "1.2.0"
+  resolved "https://codeload.github.com/NearSocial/VM/tar.gz/10064520f3b752cffcbeb13133b5c97f5d287e4a"
   dependencies:
     "@braintree/sanitize-url" "6.0.0"
     "@radix-ui/react-accordion" "^1.1.1"
@@ -6562,6 +6575,7 @@ near-social-vm@NearSocial/VM#1.1.0:
     deep-equal "^2.2.0"
     elliptic "^6.5.4"
     idb "^7.1.1"
+    iframe-resizer-react "^1.1.0"
     local-storage "^2.0.0"
     mdast-util-find-and-replace "^2.0.0"
     nanoid "^4.0.1"


### PR DESCRIPTION
Tested locally and the iframe resizer seems to work as expected.

https://near-discovery-git-feat-vm-120-near-developer-console.vercel.app/calebjacob.near/widget/IframeResizerTest