### PR TITLE
Prod: add zendesk support widget (#66)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,5 +55,33 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <!-- NEAR Discovery Zendesk Support Widget -->
+    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=1736c8d0-1d86-4080-b622-12accfdb74ca"></script>
+    <script type="text/javascript">
+    // Zendesk settings can not be configured outside of index.html :/
+    window.zESettings = {
+        webWidget: {
+          color: { theme: "#2b2f31" },
+          offset: {
+            horizontal: "10px",
+            vertical: "10px",
+            mobile: { horizontal: "2px", vertical: "65px", from: "right" },
+          },
+          contactForm: {
+            attachments: true,
+            title: { "*": "Feedback and Support" },
+            fields: [
+              {
+                id: 13149356989591,
+                prefill: { "*": localStorage.getItem("accountNameString") },
+              },
+            ],
+          },
+          launcher: {
+            label: { "*": " " },
+          },
+        },
+      };
+    </script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,9 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from "react";
 import "error-polyfill";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import "@near-wallet-selector/modal-ui/styles.css";
@@ -21,6 +26,7 @@ import Big from "big.js";
 import { NavigationWrapper } from "./components/navigation/alpha/NavigationWrapper";
 import { NetworkId, Widgets } from "./data/widgets";
 import styled from "styled-components";
+import styleZendesk from "./zendesk";
 import { Helmet } from "react-helmet";
 
 const StyledApp = styled.div`
@@ -60,6 +66,7 @@ function App(props) {
   const [availableStorage, setAvailableStorage] = useState(null);
   const [walletModal, setWalletModal] = useState(null);
   const [widgetSrc, setWidgetSrc] = useState(null);
+  const [hasStyledZendesk, setHasStyledZendesk] = useState(false);
 
   const { initNear } = useInitNear();
   const near = useNear();
@@ -88,6 +95,18 @@ function App(props) {
         }),
       });
   }, [initNear]);
+
+  useLayoutEffect(() => {
+    // ZenDesk styling is done with useLayoutEffect to avoid errors during site refresh by user
+    const zwFrame = document.getElementById("launcher");
+    if (!zwFrame || hasStyledZendesk) return;
+    try {
+      styleZendesk();
+      setHasStyledZendesk(true);
+    } catch (error) {
+      console.log("Error styling Zendesk", error);
+    }
+  });
 
   useEffect(() => {
     if (!near) {

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -43,6 +43,15 @@ export default function ViewPage(props) {
   }, [query]);
 
   useEffect(() => {
+    // Displays the Zendesk widget only if user is signed in and on the home page
+    if (!props.signedIn || !!widgetSrc) {
+      zE("webWidget", "hide");
+      return;
+    }
+    zE("webWidget", "show");
+  }, [props.signedIn, widgetSrc]);
+
+  useEffect(() => {
     setTimeout(() => {
       setWidgetSrc(
         src === viewSourceWidget && query.get("src")

--- a/src/zendesk.js
+++ b/src/zendesk.js
@@ -1,0 +1,11 @@
+// styling of Zendesk widget is done via DOM traversal as the widget 
+// configuration does not allow for custom styling :/
+export default function styleZendesk() {
+    const zwFrame = document.getElementById("launcher");
+    const zwEmbed = zwFrame.contentDocument.getElementById("Embed");
+    const zwButton = zwEmbed.getElementsByTagName("button")[0];
+    zwEmbed.style.opacity = 0.8;
+    zwButton.style.paddingRight = "1rem";
+    zwButton.style.paddingLeft = "1rem";
+    zwEmbed.getElementsByClassName("Icon")[0].style.paddingRight = "0px";
+}


### PR DESCRIPTION
* Add Zendesk support widget snippet

* Capture work in progress exploration

Based on feedback from Alex - intent is to see if we can: 
* Move it up and to the right on mobile 
* Shrink label to (?)
* Reduce opacity
* Grey - reach out to corwin for palette (using 2b2f31 for now based on inspector)
* Hide dynamically? Add an exit button - get rid of it for rest of session - zE.hide(); will do this
* Hide on certain pages? (Scope to only homepage, for example)

* added hide/show functionality for button and repositioning

* updated label

* added functionality to display the support widget on specific pages and when the user is logged in or not

* Pre-fill Account ID and whitespace cleanup

* Remove dup <script> tag

* pulled user name to auto populate help button

* Formatting and logging cleanups

Cleanup whitespace, add TODOs, comment out console.logs

* fix & refactor conditional zendesk rendering

* add widgetSrc to useEffect

* formatting

* remove console log from viewpage

* update zE.show

* refactor zendesk config

* false is default for labelVisible on mobile

* ugly script in index for zE settings

* can not move zendesk script out of html :/

* remove comment fragment

* working CSS for widget!

* move zendesk styling to separate file

* modify mobile CSS

* added useLayoutEffect to avoid crash on refresh

* remove unnecessary localstorage set/get

* remove vscode settings

* standardize html tags

* format

* added comments to viewpage zendesk widget logic

---------