### PR TITLE
fix zendesk widget being unstyled sometimes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,6 @@ import Big from "big.js";
 import { NavigationWrapper } from "./components/navigation/alpha/NavigationWrapper";
 import { NetworkId, Widgets } from "./data/widgets";
 import styled from "styled-components";
-import styleZendesk from "./zendesk";
 import { Helmet } from "react-helmet";
 
 const StyledApp = styled.div`
@@ -66,7 +65,6 @@ function App(props) {
   const [availableStorage, setAvailableStorage] = useState(null);
   const [walletModal, setWalletModal] = useState(null);
   const [widgetSrc, setWidgetSrc] = useState(null);
-  const [hasStyledZendesk, setHasStyledZendesk] = useState(false);
 
   const { initNear } = useInitNear();
   const near = useNear();
@@ -95,18 +93,6 @@ function App(props) {
         }),
       });
   }, [initNear]);
-
-  useLayoutEffect(() => {
-    // ZenDesk styling is done with useLayoutEffect to avoid errors during site refresh by user
-    const zwFrame = document.getElementById("launcher");
-    if (!zwFrame || hasStyledZendesk) return;
-    try {
-      styleZendesk();
-      setHasStyledZendesk(true);
-    } catch (error) {
-      console.log("Error styling Zendesk", error);
-    }
-  });
 
   useEffect(() => {
     if (!near) {

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { Widget } from "near-social-vm";
 import { useParams } from "react-router-dom";
 import { useQuery } from "../hooks/useQuery";
 import { useHashUrlBackwardsCompatibility } from "../hooks/useHashUrlBackwardsCompatibility";
+import styleZendesk from "../zendesk";
 
 export default function ViewPage(props) {
   // will always be empty in prod
@@ -71,6 +72,20 @@ export default function ViewPage(props) {
       });
     }, 1);
   }, [src, query, setWidgetSrc, viewSourceWidget]);
+
+  //once the zendesk widget comes online, style it
+  const queueZendeskCheck = useCallback(() => {
+    const zwFrame = document.getElementById("launcher");
+    const zwEmbed = zwFrame?.contentDocument.getElementById("Embed");
+    const zwButton = zwEmbed?.getElementsByTagName("button")[0];
+    if (zwButton) {
+      styleZendesk();
+      return;
+    }
+    setTimeout(queueZendeskCheck, 20);
+  });
+
+  useEffect(queueZendeskCheck, []);
 
   return (
     <div className="container-xl">


### PR DESCRIPTION
calling `useLayoutEffect` from `App` or `ViewPage` results in inconsistent styling since sometimes the Zendesk widget doesn't become available until after both of those components have finished their initial rendering passes (meaning `useLayoutEffect` wasn't getting called again)

This queues up a check for the existence of the widget every 20ms and, once found, styles it