### PR TITLE
Trial Base URL Patchfix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -105,7 +105,7 @@ function App(props) {
               bundle: false,
             }),
             setupKeypom({ 
-              trialBaseUrl: NetworkId == "testnet" ? "test.near.org#trial-url#" : "near.org#trial-url#", 
+              trialBaseUrl: NetworkId == "testnet" ? "test.near.org/#trial-url#" : "near.org/#trial-url#", 
               networkId: NetworkId, 
               trialSplitDelim: "/",
               signInContractId: NetworkId == "testnet" ? "v1.social08.testnet" : "social.near",


### PR DESCRIPTION
I messed up the trial account base URL. This is a super simple patch fix.