### PR TITLE
Fixes

### DIFF
--- a/src/pages/EditorPage/Banners/BannerOboarding.js
+++ b/src/pages/EditorPage/Banners/BannerOboarding.js
@@ -1,0 +1,30 @@
+import React from "react";
+import styled from "styled-components";
+
+const Wrapper = styled("div")`
+  background-color: #37cd83;
+  padding: 8px 0;
+`;
+
+const Text = styled("div")`
+  color: var(--slate-dark-1);
+  margin-left: 24px;
+`;
+
+const VsCodeLink = styled.span`
+  text-decoration: underline;
+  color: var(--blue-light-1);
+  font-weight: 700;
+  cursor: pointer;
+`;
+
+export default ({ handleExitOnboarding }) => {
+  return (
+    <Wrapper className="d-flex align-center justify-content-center">
+      <Text>
+        Welcome to the <b>Onboarding flow</b>. You can exit anytime by&nbsp;
+        <VsCodeLink onClick={handleExitOnboarding}>clicking here</VsCodeLink>
+      </Text>
+    </Wrapper>
+  );
+};

--- a/src/pages/EditorPage/OnBoarding/index.js
+++ b/src/pages/EditorPage/OnBoarding/index.js
@@ -37,6 +37,20 @@ const Tooltip = styled.div`
     margin-top: 12px;
   }
 
+  .closeIcon {
+    position: absolute;
+    font-size: 26px;
+    top: 0px;
+    right: 6px;
+    color: #999;
+    cursor: pointer;
+    border-radius: 100%;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
   .buttons {
     display: flex;
     margin-top: 24px;
@@ -47,6 +61,8 @@ const Tooltip = styled.div`
     .left {
       button {
         padding-right: 16px;
+        background: transparent;
+        color: #999;
       }
     }
 
@@ -138,6 +154,13 @@ export default ({
     }
     if (currentStep > 1) {
       selectFile(onboardingComponents.starterFork);
+    }
+
+    // glow
+    if (currentStep === 1 && refs.step1.current) {
+      refs.step1.current.className = "glow";
+    } else if (refs.step1.current) {
+      refs.step1.current.className = "";
     }
 
     // disable
@@ -236,6 +259,13 @@ export default ({
                         </button>
                       )}
                     </div>
+                  </div>
+                  <div
+                    className="closeIcon"
+                    title="Exit Onboarding flow"
+                    onClick={finishOnboarding}
+                  >
+                    <i className="bi bi-x" />
                   </div>
                 </Tooltip>
               )

--- a/src/pages/EditorPage/buttons/ForkButton.js
+++ b/src/pages/EditorPage/buttons/ForkButton.js
@@ -1,12 +1,15 @@
 import React from "react";
 
 export default ({ forkFile, refs, disable }) => (
-  <button
-    ref={refs.step1}
-    disabled={disable.forkButton}
-    className="btn btn-outline-primary me-2"
-    onClick={forkFile}
-  >
-    Fork
-  </button>
+  <div className="me-2">
+    <div ref={refs.step1}>
+      <button
+        disabled={disable.forkButton}
+        className="btn btn-outline-primary"
+        onClick={forkFile}
+      >
+        Fork
+      </button>
+    </div>
+  </div>
 );

--- a/src/pages/EditorPage/index.js
+++ b/src/pages/EditorPage/index.js
@@ -59,6 +59,11 @@ const Wrapper = styled.div`
     background: #fff;
     display: none;
     top: 40px;
+
+    h4 {
+      color: #1b1b18;
+      font-weight: 700;
+    }
   }
 
   @media only screen and (max-width: 1200px) {
@@ -71,6 +76,39 @@ const Wrapper = styled.div`
   }
 
   .glow {
+    -webkit-animation: glowing 1000ms infinite;
+    -moz-animation: glowing 1000ms infinite;
+    -o-animation: glowing 1000ms infinite;
+    animation: glowing 1000ms infinite;
+
+    @-webkit-keyframes glowing {
+      0% {
+        border-color: #63e3a4;
+        -webkit-box-shadow: 0 0 3px #63e3a4;
+      }
+      50% {
+        border-color: #63e3a4;
+        -webkit-box-shadow: 0 0 14px #63e3a4;
+      }
+      100% {
+        border-color: #63e3a4;
+        -webkit-box-shadow: 0 0 3px #63e3a4;
+      }
+    }
+    @keyframes glowing {
+      0% {
+        border-color: #63e3a4;
+        box-shadow: 0 0 3px #63e3a4;
+      }
+      50% {
+        border-color: #63e3a4;
+        box-shadow: 0 0 14px #63e3a4;
+      }
+      100% {
+        border-color: #63e3a4;
+        box-shadow: 0 0 3px #63e3a4;
+      }
+    }
   }
 
   .onboardingDisable {
@@ -561,7 +599,9 @@ const EditorPage = ({
                   width: "500px",
                 }}
               >
-                Only for big screens
+                <h4>Oops...We're gonna need a bigger screen.</h4>
+                <br />
+                Please visit the onboarding flow from a larger screen.
               </div>
             </div>
           </div>

--- a/src/pages/EditorPage/index.js
+++ b/src/pages/EditorPage/index.js
@@ -48,8 +48,31 @@ import {
 import { Helmet } from "react-helmet";
 import { recordPageView, debounceRecordClick } from "../../utils/analytics";
 import styled from "styled-components";
+import BannerOboarding from "./Banners/BannerOboarding";
 
 const Wrapper = styled.div`
+  .mobile {
+    position: absolute;
+    z-index: 95;
+    width: 100%;
+    height: 100%;
+    background: #fff;
+    display: none;
+    top: 40px;
+  }
+
+  @media only screen and (max-width: 1200px) {
+    .mobile {
+      display: block;
+    }
+    .desktop {
+      display: none;
+    }
+  }
+
+  .glow {
+  }
+
   .onboardingDisable {
     &::before {
       border: 10px;
@@ -515,6 +538,11 @@ const EditorPage = ({
     setDisable(onboarding ? onboardingDisable : {});
   }, [onboarding]);
 
+  const handleExitOnboarding = () => {
+    setCurrentStep(0);
+    history.push("/sandbox");
+  };
+
   return (
     <Wrapper>
       <Helmet>
@@ -524,6 +552,21 @@ const EditorPage = ({
         <meta property="og:description" content={meta.description} />
       </Helmet>
       <div style={{ position: "relative" }} onPointerUp={debounceRecordClick}>
+        {onboarding && (
+          <div className="mobile">
+            <div className={`d-flex min-vh-100 `}>
+              <div
+                className="container-fluid mt-5"
+                style={{
+                  width: "500px",
+                }}
+              >
+                Only for big screens
+              </div>
+            </div>
+          </div>
+        )}
+
         {onboarding && (
           <OnBoarding
             onboarding={onboarding}
@@ -567,7 +610,10 @@ const EditorPage = ({
               />
             )}
             <div className={showEditor ? `` : ``}>
-              <VsCodeBanner />
+              {onboarding || <VsCodeBanner />}
+              {onboarding && (
+                <BannerOboarding handleExitOnboarding={handleExitOnboarding} />
+              )}
 
               <div
                 className="container-fluid mt-1"

--- a/src/pages/EditorPage/utils/onboarding.js
+++ b/src/pages/EditorPage/utils/onboarding.js
@@ -83,7 +83,7 @@ export const onboardingSteps = {
   },
   step7: {
     component: <Step7 />,
-    button: "Confirm Code Copy",
+    button: "Confirm Embed",
     tooltipAdjust: {
       x: 0,
       y: 100,


### PR DESCRIPTION
1. Added `X` icon to the tootip to close the onboarding flow.
2. Added top bar with Onboarding Welcome message and button to close onboarding flow.
3. Hiding onboarding flow for mobile users (breakpoint 1199px).
4. Change styling for Back button.

I need a text for the mobile users, informing that the onboarding flow is available only for desktops.