### PR TITLE
fix: Make sure mobile menu close btn width persists

### DIFF
--- a/src/components/navigation/org/mobile/MenuLeft.js
+++ b/src/components/navigation/org/mobile/MenuLeft.js
@@ -54,6 +54,8 @@ const StyledMenu = styled.div`
 
     svg {
       margin: 0;
+      min-width: 24px;
+      min-height: 24px;
 
       path {
         stroke: #1b1b18;


### PR DESCRIPTION
Fixing issue with 'x' width:
<img width="486" alt="Screen Shot 2023-04-26 at 3 22 28 PM" src="https://user-images.githubusercontent.com/24921205/234588673-73b3a3b7-e453-4492-a0fb-be0eb577d518.png">


