### PR TITLE
Use https for mainnet relayer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -245,7 +245,7 @@ function App(props) {
               relayerUrl:
                 NetworkId === "testnet"
                   ? "http://34.70.226.83:3030/relay"
-                  : "http://near-relayer-mainnet.api.pagoda.co/relay",
+                  : "https://near-relayer-mainnet.api.pagoda.co/relay",
             }),
             setupKeypom({
               trialBaseUrl:


### PR DESCRIPTION
Updates mainnet relayer to use https as this is required by the browser when we're viewing near-discovery via https (e.g. not on localhost)