### PR TITLE
ONB-67 Added logic to remember the page before login and redirect back on success

### DIFF
--- a/src/components/navigation/desktop/DesktopNavigation.tsx
+++ b/src/components/navigation/desktop/DesktopNavigation.tsx
@@ -194,7 +194,10 @@ export const DesktopNavigation = () => {
 
   function handleSignIn(event: any) {
     clearAnalytics(event);
-    requestSignIn();
+    const redirect = router.asPath !== '/'
+      ? router.asPath
+      : null;
+    requestSignIn(redirect);
   }
 
   return (
@@ -251,7 +254,11 @@ export const DesktopNavigation = () => {
                 className="create-account"
                 onClick={(event) => {
                   clearAnalytics(event);
-                  router.push('/signup');
+                  router.push(
+                    `/signup${router.asPath !== '/'
+                      ? `?redirect=${router.asPath}`
+                      : ''}`
+                  );
                 }}
               >
                 Create Account

--- a/src/components/navigation/mobile/MenuLeft.tsx
+++ b/src/components/navigation/mobile/MenuLeft.tsx
@@ -179,7 +179,10 @@ export function MenuLeft(props: Props) {
   function handleSignIn(event: UIEvent) {
     clearAnalytics(event);
     props.onCloseMenu();
-    requestSignIn();
+    const redirect = router.asPath !== '/'
+      ? router.asPath
+      : null;
+    requestSignIn(redirect);
   }
 
   function search() {
@@ -215,7 +218,11 @@ export function MenuLeft(props: Props) {
               className="create-account"
               onClick={(event) => {
                 clearAnalytics(event);
-                router.push('/signup');
+                router.push(
+                  `/signup${router.asPath !== '/'
+                    ? `?redirect=${router.asPath}`
+                    : ''}
+                `);
               }}
             >
               Create Account

--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -101,8 +101,8 @@ export default function VmInitializer() {
     [walletModal],
   );
 
-  const requestSignIn = useCallback(() => {
-    router.push('/signin');
+  const requestSignIn = useCallback((redirect?: string | null) => {
+    router.push(`signin${redirect ? `?redirect=${redirect}` : ''}`);
   }, [router]);
 
   const logOut = useCallback(async () => {

--- a/src/pages/auth-callback.tsx
+++ b/src/pages/auth-callback.tsx
@@ -25,7 +25,7 @@ const AuthCallbackPage: NextPageWithLayout = () => {
       const accountId = searchParams.get('accountId');
       const publicKey = searchParams.get('publicKey');
       const isRecovery = searchParams.get('isRecovery') === 'true';
-
+      const redirect = searchParams.get("redirect");
       let email = window.localStorage.getItem('emailForSignIn');
 
       while (!email) {
@@ -104,8 +104,11 @@ const AuthCallbackPage: NextPageWithLayout = () => {
                 );
 
                 setStatusMessage('Redirecting to app...');
-
-                window.location.href = '/';
+                if (redirect) {
+                  window.location.href = redirect;
+                } else {
+                  window.location.href = "/";
+                }
               },
             );
           }

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -26,9 +26,11 @@ const SignInPage: NextPageWithLayout = () => {
 
   const onSubmit = handleSubmit(async (data) => {
     if (!data.email) return;
+    const searchParams = new URLSearchParams(location.search);
+    const redirect = searchParams.get("redirect");
     try {
-      const { publicKey, email } = await handleCreateAccount(null, data.email, true);
-      router.push(`/verify-email?publicKey=${publicKey}&email=${email}&isRecovery=true`);
+      const { publicKey, email } = await handleCreateAccount(null, data.email, true, redirect);
+      router.push(`/verify-email?publicKey=${publicKey}&email=${email}&isRecovery=true${redirect ? `&redirect=${redirect}` : ""}`);
     } catch (error: any) {
       console.log(error);
 

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -67,13 +67,14 @@ const SignUpPage: NextPageWithLayout = () => {
 
   const onSubmit = handleSubmit(async (data) => {
     if (!data?.username || !data.email) return;
+    const redirect = router.query?.redirect;
     try {
       const fullAccountId = `${data.username}.${network.fastAuth.accountIdSuffix}`;
-      const { publicKey, accountId, email } = await handleCreateAccount(fullAccountId, data.email);
+      const { publicKey, accountId, email } = await handleCreateAccount(fullAccountId, data.email, false, redirect);
       router.push(
         `/verify-email?publicKey=${encodeURIComponent(publicKey)}&accountId=${encodeURIComponent(
           accountId,
-        )}&email=${encodeURIComponent(email)}`,
+        )}&email=${encodeURIComponent(email)}${redirect ? `&redirect=${redirect}` : ""}`,
       );
     } catch (error: any) {
       toast.error(error.message);

--- a/src/pages/verify-email.tsx
+++ b/src/pages/verify-email.tsx
@@ -25,7 +25,7 @@ const VerifyEmailPage: NextPageWithLayout = () => {
 
     try {
       await sendSignInLinkToEmail(firebaseAuth, query.email, {
-        url: `${window.location.origin}/auth-callback?publicKey=${query.publicKey}&accountId=${query.accountId}`,
+        url: `${window.location.origin}/auth-callback?publicKey=${query.publicKey}&accountId=${query.accountId}${query?.redirect ? `&redirect=${query.redirect}` : ""}`,
         handleCodeInApp: true,
       });
       toast.success('Email resent successfully!');
@@ -40,12 +40,13 @@ const VerifyEmailPage: NextPageWithLayout = () => {
     }
   };
 
+  const redirect = query?.redirect ? `?redirect=${query.redirect}` : "";
   return (
     <StyledContainer>
       <FormContainer onSubmit={handleResendEmail}>
         <header>
           <a
-            href={query?.isRecovery === 'true' ? '/signin' : '/signup'}
+            href={query?.isRecovery === 'true' ? `/signin${redirect}` : `/signup${redirect}`}
             style={{ textDecoration: 'underline', color: 'black' }}
           >
             <small>Go back</small>

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -7,7 +7,7 @@ type AuthState = {
   availableStorage: Big | null;
   logOut: () => Promise<void>;
   refreshAllowance: () => Promise<void>;
-  requestSignIn: () => void;
+  requestSignIn: (redirect?: string | null) => void;
   requestSignInWithWallet: (event: any) => void;
   signedIn: boolean;
 };

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -21,7 +21,7 @@ export const getCorrectAccessKey = async (userName, firstKeyPair, secondKeyPair)
   }
 };
 
-export const handleCreateAccount = async (accountId, email, isRecovery) => {
+export const handleCreateAccount = async (accountId, email, isRecovery, redirect) => {
   const keyPair = await createKey(email);
   const publicKey = keyPair.getPublicKey().toString();
 
@@ -37,7 +37,8 @@ export const handleCreateAccount = async (accountId, email, isRecovery) => {
   await sendSignInLinkToEmail(firebaseAuth, email, {
     url: encodeURI(
       `${window.location.origin}/auth-callback?publicKey=${publicKey}&accountId=${accountId}` +
-        (isRecovery ? '&isRecovery=true' : ''),
+        (isRecovery ? '&isRecovery=true' : '') +
+        (redirect ? `&redirect=${redirect}` : ''),
     ),
     handleCodeInApp: true,
   });


### PR DESCRIPTION
This PR contains implementation for remembering the page user was at prior to sign in /sign up and redirect back to it when user successfully login. 

Basic flow is that it adds a new param called `redirect` where it holds the url path. Then this param gets passed all the way down to `auth-callback` logic where it redirect to the page if `redirect` param exist. 

During the implementation, I came across strange behaviour where on both sign in / sign up success, it redirects to `signup` page with an error first and then after 5 seconds, it actually completes the login and redirect to the page accordingly. This behaviour existed before this implementation. 

Before sign up:
![Greenshot 2023-05-12 15 39 48](https://github.com/near/near-discovery/assets/6027014/ee92693e-b365-430e-9e47-a9cd2ced0eaa)

During sign up:
![Greenshot 2023-05-12 15 40 19](https://github.com/near/near-discovery/assets/6027014/bcb60ede-1b1b-4a15-aff8-b4a52f816769)

On sign up success:
![Greenshot 2023-05-12 15 42 08](https://github.com/near/near-discovery/assets/6027014/a62d2fc2-b2bd-42b8-a56c-3d16eb7b29dd)

