### PR TITLE
DEC-1218 Bug fix on redirect query param stacking 

### DIFF
--- a/src/components/navigation/desktop/DesktopNavigation.tsx
+++ b/src/components/navigation/desktop/DesktopNavigation.tsx
@@ -17,6 +17,7 @@ import { NotificationButton } from '../NotificationButton';
 import { MainNavigationMenu } from './MainNavigationMenu';
 import { TypeAheadDropdown } from './TypeAheadDropdown';
 import { UserDropdownMenu } from './UserDropdownMenu';
+import { getRedirectQueryParams } from '@/utils/navigation';
 
 const StyledNavigation = styled.div`
   z-index: 1000;
@@ -194,10 +195,8 @@ export const DesktopNavigation = () => {
 
   function handleSignIn(event: any) {
     clearAnalytics(event);
-    const redirect = router.asPath !== '/'
-      ? router.asPath
-      : null;
-    requestSignIn(redirect);
+    const queryParam = getRedirectQueryParams(router);
+    requestSignIn(queryParam);
   }
 
   return (
@@ -254,11 +253,7 @@ export const DesktopNavigation = () => {
                 className="create-account"
                 onClick={(event) => {
                   clearAnalytics(event);
-                  router.push(
-                    `/signup${router.asPath !== '/'
-                      ? `?redirect=${router.asPath}`
-                      : ''}`
-                  );
+                  router.push(`/signup${getRedirectQueryParams(router)}`);
                 }}
               >
                 Create Account

--- a/src/components/navigation/mobile/MenuLeft.tsx
+++ b/src/components/navigation/mobile/MenuLeft.tsx
@@ -16,6 +16,7 @@ import NearLogotype from '../icons/near-logotype.svg';
 import SearchIcon from '../icons/search.svg';
 import { NotificationButton } from '../NotificationButton';
 import { AccordionMenu } from './AccordionMenu';
+import { getRedirectQueryParams } from '@/utils/navigation';
 
 type Props = {
   onCloseMenu: () => void;
@@ -179,10 +180,8 @@ export function MenuLeft(props: Props) {
   function handleSignIn(event: UIEvent) {
     clearAnalytics(event);
     props.onCloseMenu();
-    const redirect = router.asPath !== '/'
-      ? router.asPath
-      : null;
-    requestSignIn(redirect);
+    const queryParam = getRedirectQueryParams(router);
+    requestSignIn(queryParam);
   }
 
   function search() {
@@ -218,11 +217,7 @@ export function MenuLeft(props: Props) {
               className="create-account"
               onClick={(event) => {
                 clearAnalytics(event);
-                router.push(
-                  `/signup${router.asPath !== '/'
-                    ? `?redirect=${router.asPath}`
-                    : ''}
-                `);
+                router.push(`/signup${getRedirectQueryParams(router)}`);
               }}
             >
               Create Account

--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -101,8 +101,8 @@ export default function VmInitializer() {
     [walletModal],
   );
 
-  const requestSignIn = useCallback((redirect?: string | null) => {
-    router.push(`signin${redirect ? `?redirect=${redirect}` : ''}`);
+  const requestSignIn = useCallback((queryParam?: string) => {
+    router.push(`signin${queryParam}`);
   }, [router]);
 
   const logOut = useCallback(async () => {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,31 @@
+import type { NextRouter } from "next/router";
+
+const ignoreRedirectPaths = [
+  "/",
+  "/signin",
+  "/signup",
+];
+
+export const getRedirectQueryParams = (router: NextRouter): string => {
+  const {
+    query,
+    asPath
+  } = router;
+  
+  // remove unwanted hidden query param from next router
+  delete query?.arbitrary;
+
+  // recreating pathname from asPath to avoid /arbitrary path from router.pathname
+  const path = asPath.split('?')[0];
+
+  if (ignoreRedirectPaths.includes(path)) return "";
+
+  const queryParams = {
+    ...query,
+    redirect: path,
+  };
+
+  return Object.keys(queryParams).length > 0
+    ? `?${new URLSearchParams(queryParams).toString()}`
+    : "";
+};


### PR DESCRIPTION
This PR contains improved logic on redirect using query param that fixes `redirect` query param stacking issue. 

Also if user's previous pages were either `signin` or `signup` page, it doesn't get passed to query param. 