### PR TITLE
Convert to <Button />

### DIFF
--- a/src/components/lib/Button/Button.tsx
+++ b/src/components/lib/Button/Button.tsx
@@ -13,7 +13,6 @@ type Props = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size'> & {
   iconRight?: string;
   label: string;
   loading?: boolean;
-  onClick?: () => void;
   size?: 'small' | 'default' | 'large';
   type?: 'button' | 'submit';
   variant?: Variant;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -7,11 +7,11 @@ export const Navigation = () => {
   const [matches, setMatches] = useState(true);
 
   useEffect(() => {
-    setMatches(window.matchMedia('(min-width: 1060px)').matches);
+    setMatches(window.matchMedia('(min-width: 1200px)').matches);
   }, []);
 
   useEffect(() => {
-    window.matchMedia('(min-width: 1060px)').addEventListener('change', (e) => setMatches(e.matches));
+    window.matchMedia('(min-width: 1200px)').addEventListener('change', (e) => setMatches(e.matches));
   }, []);
 
   return (

--- a/src/components/navigation/desktop/DesktopNavigation.tsx
+++ b/src/components/navigation/desktop/DesktopNavigation.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
+import { Button } from '@/components/lib/Button';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useAuthStore } from '@/stores/auth';
 import { recordEvent } from '@/utils/analytics';
@@ -28,10 +29,6 @@ const StyledNavigation = styled.div`
   background-color: white;
   padding-top: 16px;
   padding-bottom: 16px;
-
-  button {
-    border: 0;
-  }
 
   &.border-bottom {
     border-bottom: 1px solid #e3e3e0;
@@ -103,43 +100,7 @@ const StyledNavigation = styled.div`
     margin-left: auto;
     position: relative;
     z-index: 10;
-
-    .sign-in,
-    .create-account {
-      border-radius: 50px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 40px;
-      padding: 0 20px;
-      font-size: 14px;
-      font-weight: 600;
-      white-space: nowrap;
-    }
-
-    .sign-in {
-      color: #1b1b18;
-      margin-right: 10px;
-      border: 1px solid transparent;
-      :hover {
-        background-color: #f3f3f2;
-      }
-      :focus {
-        background-color: white;
-        border: 1px solid #604cc8;
-        box-shadow: 0px 0px 0px 4px #cbc7f4;
-      }
-    }
-    .create-account {
-      background-color: #161615;
-      color: white;
-      :hover {
-        background-color: #2e2e2b;
-      }
-      :focus {
-        box-shadow: 0px 0px 0px 4px #cbc7f4;
-      }
-    }
+    gap: 10px;
   }
 `;
 
@@ -247,18 +208,16 @@ export const DesktopNavigation = () => {
         <div className="right-side-actions">
           {!signedIn && (
             <>
-              <button className="sign-in" onClick={handleSignIn}>
-                Sign In
-              </button>
-              <button
-                className="create-account"
+              <Button label="Sign In" variant="secondary" onClick={handleSignIn} />
+
+              <Button
+                label="Create Account"
+                variant="primary"
                 onClick={(event) => {
                   clearAnalytics(event);
                   router.push(`/signup${getRedirectQueryParams(router)}`);
                 }}
-              >
-                Create Account
-              </button>
+              />
             </>
           )}
           {signedIn && (

--- a/src/components/navigation/mobile/MenuLeft.tsx
+++ b/src/components/navigation/mobile/MenuLeft.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import React from 'react';
 import styled from 'styled-components';
 
+import { Button } from '@/components/lib/Button';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useAuthStore } from '@/stores/auth';
 import { flushEvents, recordClick } from '@/utils/analytics';
@@ -53,27 +54,9 @@ const StyledMenu = styled.div`
   }
 
   .close-button {
-    background-color: #f3f3f2;
-    border: 0.5px solid #e3e3e0;
     position: absolute;
     right: 25px;
-    top: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-
-    svg {
-      margin: 0;
-      min-width: 24px;
-      min-height: 24px;
-
-      path {
-        stroke: #1b1b18;
-      }
-    }
+    top: 23px;
   }
 
   .search-btn {
@@ -103,28 +86,10 @@ const StyledMenu = styled.div`
 
   .bottom-btns {
     margin-top: auto;
-
-    button {
-      width: 100%;
-      height: 48px;
-      border-radius: 50px;
-      font-size: 16px;
-      font-weight: 600;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .sign-in {
-      background-color: #f3f3f2;
-      color: #1b1b18;
-      border: 0.5px solid #e3e3e0;
-      margin: 20px 0;
-    }
-    .create-account {
-      background-color: #161615;
-      color: white;
-      border: 0;
-    }
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: 16px;
   }
 
   .logged-in-btns {
@@ -199,9 +164,15 @@ export function MenuLeft(props: Props) {
   return (
     <StyledMenu className={props.showMenu ? 'show' : ''}>
       <div className="left-side">
-        <button className="close-button" onClick={props.onCloseMenu}>
-          <Image src={CloseIcon} alt="Close" />
-        </button>
+        <Button
+          label="Close Menu"
+          icon="ph-bold ph-x"
+          size="small"
+          variant="secondary"
+          className="close-button"
+          onClick={props.onCloseMenu}
+        />
+
         <Image className="near-logotype" src={NearLogotype} alt="NEAR logotype" onClick={() => router.push('/')} />
         <button className="search-btn" style={{ backgroundImage: `url(${SearchIcon.src})` }} onClick={search}>
           Search NEAR
@@ -210,18 +181,17 @@ export function MenuLeft(props: Props) {
 
         {!signedIn && (
           <div className="bottom-btns">
-            <button className="sign-in" onClick={handleSignIn}>
-              Sign in
-            </button>
-            <button
-              className="create-account"
+            <Button label="Sign in" variant="secondary" size="large" onClick={handleSignIn} />
+
+            <Button
+              label="Create Account"
+              variant="primary"
+              size="large"
               onClick={(event) => {
                 clearAnalytics(event);
                 router.push(`/signup${getRedirectQueryParams(router)}`);
               }}
-            >
-              Create Account
-            </button>
+            />
           </div>
         )}
         {signedIn && (

--- a/src/components/navigation/mobile/TopNavigation.tsx
+++ b/src/components/navigation/mobile/TopNavigation.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { Button } from '@/components/lib/Button';
 import { VmComponent } from '@/components/vm/VmComponent';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useAuthStore } from '@/stores/auth';
@@ -175,17 +176,11 @@ export function TopNavigation(props: Props) {
 
       {!signedIn && (
         <>
-          <button className="create-account" onClick={handleCreateAccount}>
-            Create Account
-          </button>
+          <Button label="Create Account" variant="secondary" size="small" onClick={handleCreateAccount} />
         </>
       )}
 
-      <button onClick={() => props.onClickShowMenu()} className="mobile-nav-profile-btn">
-        <div className="menu-icon">
-          <i className="ph-bold ph-list"></i>
-        </div>
-      </button>
+      <Button label="Menu" icon="ph-bold ph-list" variant="primary" size="small" onClick={props.onClickShowMenu} />
     </StyledNavigation>
   );
 }

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
 
+import { Button } from '@/components/lib/Button';
 import { openToast } from '@/components/lib/Toast';
 import { useClearCurrentComponent } from '@/hooks/useClearCurrentComponent';
 import { useDefaultLayout } from '@/hooks/useLayout';
@@ -77,14 +78,9 @@ const SignInPage: NextPageWithLayout = () => {
             required
           />
         </InputContainer>
-        <StyledButton onClick={onSubmit} type="button">
-          {/* <IconFingerPrint /> */}
-          Continue
-        </StyledButton>
-        <StyledButton onClick={requestSignInWithWallet} type="button">
-          {/* <IconFingerPrint /> */}
-          Continue with wallet
-        </StyledButton>
+
+        <Button label="Continue" variant="affirmative" onClick={onSubmit} />
+        <Button label="Continue with wallet" variant="primary" onClick={requestSignInWithWallet} />
       </FormContainer>
     </StyledContainer>
   );
@@ -142,27 +138,5 @@ const InputContainer = styled.div`
 
   .subText {
     font-size: 12px;
-  }
-`;
-
-const StyledButton = styled.button`
-  // width: 100%;
-  padding: 8px;
-  border: none;
-  border-radius: 50px;
-  font-size: 14px;
-  margin-top: 4px;
-  min-height: 40px;
-  cursor: pointer;
-  background-color: #6be89e;
-  color: #000000;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-
-  &:focus {
-    outline: none;
   }
 `;

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
 
+import { Button } from '@/components/lib/Button';
 import { openToast } from '@/components/lib/Toast';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
@@ -198,9 +199,8 @@ const SignUpPage: NextPageWithLayout = () => {
             <ErrorText role="alert">{errors.username?.message}</ErrorText>
           )}
         </InputContainer>
-        <StyledButton onClick={onSubmit} type="button">
-          Continue
-        </StyledButton>
+
+        <Button label="Continue" variant="affirmative" onClick={onSubmit} />
 
         <hr style={{ borderColor: 'hsl(55, 1.7%, 51.9%)' }} />
 
@@ -277,26 +277,5 @@ const InputContainer = styled.div`
     .success {
       color: hsla(155, 66%, 32%, 1);
     }
-  }
-`;
-
-const StyledButton = styled.button`
-  padding: 8px;
-  border: none;
-  border-radius: 50px;
-  font-size: 14px;
-  margin-top: 4px;
-  min-height: 40px;
-  cursor: pointer;
-  background-color: #6be89e;
-  color: #000000;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-
-  &:focus {
-    outline: none;
   }
 `;

--- a/src/pages/verify-email.tsx
+++ b/src/pages/verify-email.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import styled from 'styled-components';
 
+import { Button } from '@/components/lib/Button';
 import { openToast } from '@/components/lib/Toast';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useCurrentComponentStore } from '@/stores/current-component';
@@ -75,9 +76,7 @@ const VerifyEmailPage: NextPageWithLayout = () => {
 
         <p>Check your inbox to activate your account.</p>
 
-        <StyledButton onClick={handleResendEmail} type="button">
-          Resend Email
-        </StyledButton>
+        <Button label="Resend Email" variant="secondary" onClick={handleResendEmail} />
       </FormContainer>
     </StyledContainer>
   );
@@ -107,24 +106,4 @@ const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
   gap: 16px;
-`;
-const StyledButton = styled.button`
-  padding: 8px;
-  border: none;
-  border-radius: 50px;
-  font-size: 14px;
-  margin-top: 4px;
-  min-height: 40px;
-  cursor: pointer;
-  background-color: #6be89e;
-  color: #000000;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-
-  &:focus {
-    outline: none;
-  }
 `;


### PR DESCRIPTION
- Converted main nav to use `<Button />`
- Converted /signin and /signup to use `<Button />`

For context, `components/lib/Button` was ported over from `DIG.Button` to improve performance within the native React environment.

All of the sandbox and onboarding buttons can be converted over at a later time.