### PR TITLE
fix: URI encoding on search pressed for desktop view

### DIFF
--- a/src/components/navigation/desktop/DesktopNavigation.tsx
+++ b/src/components/navigation/desktop/DesktopNavigation.tsx
@@ -177,7 +177,7 @@ export const DesktopNavigation = () => {
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              router.push(`/${components.search.indexPage}?term=${searchTerm}`);
+              router.push(`/${components.search.indexPage}?term=${encodeURIComponent(searchTerm)}`);
               setSearchIsFocused(false);
             }}
           >


### PR DESCRIPTION
This fixes the search URI encoding when making a search and directly pressing `enter` on desktop view. Related PR for fixing it on the widget side too: https://github.com/near/near-discovery-components/pull/112