### PR TITLE
Fix Share Preview

### DIFF
--- a/src/components/MetaTags.tsx
+++ b/src/components/MetaTags.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 type Props = {
   title: string;
   description: string;
+  image?: string | null;
 };
 
 export function MetaTags(props: Props) {
@@ -12,6 +13,10 @@ export function MetaTags(props: Props) {
       <meta name="description" content={props.description} />
       <meta property="og:title" content={props.title} />
       <meta property="og:description" content={props.description} />
+      <meta property="og:type" content="website" />
+      <meta content={props.image || `${process.env.NEXT_PUBLIC_HOSTNAME}/bos-meta.png`} property="og:image" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@NEARProtocol" />
     </Head>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,12 +22,6 @@ const VmInitializer = dynamic(() => import('../components/vm/VmInitializer'), {
   ssr: false,
 });
 
-const meta = {
-  title: 'NEAR',
-  description: "Let's build decentralized experiences.",
-  image: `${process.env.NEXT_PUBLIC_HOSTNAME}/bos-meta.png`,
-};
-
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
 };
@@ -46,7 +40,6 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
     <>
       <Head>
         <meta name="google-site-verification" content="CDEVFlJTyVZ2vM7ePugKgWsl_7Rd-MrfDv42u0vZ0B0" />
-        <meta content={meta.image} property="og:image" />
       </Head>
 
       <Script id="phosphor-icons" src="https://unpkg.com/@phosphor-icons/web@2.0.3" async />

--- a/src/pages/s/[urlShareIndicator].tsx
+++ b/src/pages/s/[urlShareIndicator].tsx
@@ -122,8 +122,6 @@ export const getServerSideProps: GetServerSideProps<{
     meta = await returnMetaPreviewForPost(accountId, blockHeight);
   }
 
-  console.log(meta);
-
   return {
     props: {
       meta,

--- a/src/pages/s/[urlShareIndicator].tsx
+++ b/src/pages/s/[urlShareIndicator].tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { openToast } from '@/components/lib/Toast';
+import { MetaTags } from '@/components/MetaTags';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import type { NextPageWithLayout } from '@/utils/types';
 
@@ -121,6 +122,8 @@ export const getServerSideProps: GetServerSideProps<{
     meta = await returnMetaPreviewForPost(accountId, blockHeight);
   }
 
+  console.log(meta);
+
   return {
     props: {
       meta,
@@ -145,17 +148,7 @@ const ShareUrlPage: NextPageWithLayout = ({ meta }: InferGetServerSidePropsType<
   }, [meta, router]);
 
   if (meta) {
-    return (
-      <Head>
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:site" content="@NEARProtocol" />
-        <meta property="og:title" content={`${meta.title} | NEAR`} />
-        <meta property="og:description" content={meta.description} />
-        <meta property="og:type" content="website" />
-
-        {meta.imageUrl && <meta property="og:image" content={meta.imageUrl} />}
-      </Head>
-    );
+    return <MetaTags title={meta.title} description={meta.description} image={meta.imageUrl} />;
   }
 
   return null;


### PR DESCRIPTION
Fixes the latest PR for implementing a share URL. I didn't realize we had duplicate `og:image` tags and crawlers would only respect the first entry (which is our default image). This PR makes sure we only have one set of meta tags on each page.