### PR TITLE
chore: update mpc-recovery mainnet url

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,7 +8,7 @@ export const networks: Record<NetworkId, Network> = {
     walletUrl: 'https://wallet.near.org',
     helperUrl: 'https://helper.mainnet.near.org',
     fastAuth: {
-      mpcRecoveryUrl: 'https://mpc-recovery-prod-7tk2cmmtcq-ue.a.run.app',
+      mpcRecoveryUrl: 'https://mpc-recovery-leader-mainnet-cg7nolnlpa-ue.a.run.app',
       authHelperUrl: 'https://api.kitwallet.app',
       accountIdSuffix: 'near',
       firebase: {


### PR DESCRIPTION
mpc-recovery is moving to a different GCP project, this is going to be its new URL