### PR TITLE
Fix: Rudderstack Analytics Page Load Metric

### DIFF
--- a/src/hooks/usePageAnalytics.ts
+++ b/src/hooks/usePageAnalytics.ts
@@ -8,6 +8,16 @@ export function usePageAnalytics() {
   const { asPath } = router;
   useEffect(() => {
     const justPath = asPath.split('?')[0];
-    recordPageView(justPath);
+    // wait for analytics library to initilize on initial page load before sending event
+    if (window.analyticsInitialized) {
+      recordPageView(justPath);
+    } else {
+      const checkInterval = setInterval(() => {
+        if (window.analyticsInitialized) {
+          recordPageView(justPath);
+          clearInterval(checkInterval);
+        }
+      }, 100);
+    }
   }, [asPath]);
 }

--- a/src/hooks/usePageAnalytics.ts
+++ b/src/hooks/usePageAnalytics.ts
@@ -8,16 +8,6 @@ export function usePageAnalytics() {
   const { asPath } = router;
   useEffect(() => {
     const justPath = asPath.split('?')[0];
-    // wait for analytics library to initilize on initial page load before sending event
-    if (window.analyticsInitialized) {
-      recordPageView(justPath);
-    } else {
-      const checkInterval = setInterval(() => {
-        if (window.analyticsInitialized) {
-          recordPageView(justPath);
-          clearInterval(checkInterval);
-        }
-      }, 100);
-    }
+    recordPageView(justPath);
   }, [asPath]);
 }

--- a/src/utils/rudder-analytics.ts
+++ b/src/utils/rudder-analytics.ts
@@ -14,6 +14,7 @@ let anonymousUserIdCreatedAt = '';
 declare global {
   interface Window {
     rudderanalytics: Analytics | undefined;
+    analyticsInitialized: boolean;
   }
 }
 
@@ -62,6 +63,7 @@ export async function init() {
     window.rudderanalytics.load(rudderAnalyticsKey, analyticsUrl);
     rudderAnalytics = window.rudderanalytics;
     if (rudderAnalytics) rudderAnalytics.setAnonymousId(getAnonymousId());
+    window.analyticsInitialized = true;
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
Rudderstack Page Load events were not consistent with that of Segments. We found the issue to be related to Rudderstack analytics SDK not loading fast enough to fire off the event. 

In this PR, we wait to check if rudder-analytics SDK is ready, if it is not, we push the page Load event into a pendingEvents queue that we flush right after rudder-analytics sdk has been initialized. 