### PR TITLE
fix: withdraw text typo

### DIFF
--- a/src/components/navigation/desktop/UserDropdownMenu.tsx
+++ b/src/components/navigation/desktop/UserDropdownMenu.tsx
@@ -190,7 +190,7 @@ export const UserDropdownMenu = () => {
           </DropdownMenu.Item>
           <DropdownMenu.Item className="DropdownMenuItem" onClick={() => withdrawStorage()}>
             <i className="ph-duotone ph-bank"></i>
-            {availableStorage && `Withdraw ${availableStorage.div(1000).toFixed(2)}kb}`}
+            {availableStorage && `Withdraw ${availableStorage.div(1000).toFixed(2)}kb`}
           </DropdownMenu.Item>
           <DropdownMenu.Item className="DropdownMenuItem" onClick={() => logOut()}>
             <i className="ph-duotone ph-sign-out"></i>


### PR DESCRIPTION
Removed an extra brace after `kb` in the navigation dropdown menu

<img width="232" alt="image" src="https://github.com/near/near-discovery/assets/59515280/42cabaa7-d5ae-4a6a-ad38-c1c179bfe1d5">
