### PR TITLE
feat: allow signIn with only LAK for no webauthn browsers

### DIFF
--- a/src/components/lib/Toast/Toaster.tsx
+++ b/src/components/lib/Toast/Toaster.tsx
@@ -7,6 +7,7 @@ export function Toaster() {
 
   const iconsByType: Record<ToastType, string> = {
     INFO: 'ph ph-info',
+    WARNING: 'ph ph-warning',
     ERROR: 'ph ph-warning-circle',
     SUCCESS: 'ph ph-check-circle',
   };
@@ -36,7 +37,7 @@ export function Toaster() {
               {toast.description && <T.Description>{toast.description}</T.Description>}
             </T.Content>
 
-            <T.CloseButton />
+            <T.CloseButton data-type={type} />
           </T.Root>
         );
       })}

--- a/src/components/lib/Toast/store.ts
+++ b/src/components/lib/Toast/store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type ToastType = 'INFO' | 'ERROR' | 'SUCCESS';
+export type ToastType = 'INFO' | 'ERROR' | 'SUCCESS' | 'WARNING';
 
 export interface Toast {
   description?: string;

--- a/src/components/lib/Toast/styles.ts
+++ b/src/components/lib/Toast/styles.ts
@@ -70,6 +70,10 @@ export const Root = styled(ToastPrimitive.Root)`
   &[data-type='INFO'] {
     background: var(--sand12);
   }
+  &[data-type='WARNING'] {
+    background: var(--amber4);
+    color: var(--amber12)
+  }
 `;
 
 export const Content = styled.div`
@@ -114,5 +118,9 @@ export const CloseButton = styled(ToastPrimitive.Close)`
 
   i {
     font-size: 0.8rem;
+  }
+
+  &[data-type='WARNING'] {
+    color: var(--amber12)
   }
 `;

--- a/src/pages/auth-callback.tsx
+++ b/src/pages/auth-callback.tsx
@@ -63,7 +63,7 @@ const AuthCallbackPage: NextPageWithLayout = () => {
             const data = {
               ...(accountId && accountId.includes('.') ? { near_account_id: accountId } : {}),
               create_account_options: {
-                full_access_keys: [publicKey],
+                ...(publicKey ? {full_access_keys: [publicKey]} : {}),
                 limited_access_keys: [
                   {
                     public_key: limitedAccessKey.getPublicKey().toString(),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,8 @@
+import { isPassKeyAvailable } from '@near-js/biometric-ed25519';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
+import { openToast } from '@/components/lib/Toast';
 import { MetaTags } from '@/components/MetaTags';
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { NearOrgHomePage } from '@/components/near-org/NearOrg.HomePage';
@@ -38,6 +40,21 @@ const HomePage: NextPageWithLayout = () => {
       setComponentProps(router.query);
     }
   }, [router.query, signedIn, signedInOptimistic]);
+
+  useEffect(() => {
+    if(signedIn) {
+      isPassKeyAvailable().then((passKeyAvailable: boolean) => {
+        if(!passKeyAvailable) {
+          openToast({
+            title: 'Limited Functionality',
+            type: 'WARNING',
+            description: 'To access all account features, try using a browser that supports passkeys',
+            duration: 5000,
+          })
+        }
+      })
+    }
+  },[signedIn])
 
   if (signedIn || signedInOptimistic) {
     return (

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,3 +1,4 @@
+import { getKeys, isPassKeyAvailable } from '@near-js/biometric-ed25519';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
@@ -34,7 +35,7 @@ const SignInPage: NextPageWithLayout = () => {
 
     try {
       const { publicKey, email } = await handleCreateAccount(null, data.email, true);
-      router.push(`/verify-email?publicKey=${publicKey}&email=${email}&isRecovery=true`);
+      router.push(`/verify-email?email=${email}&isRecovery=true` + (publicKey ? `&publicKey=${encodeURIComponent(publicKey)}` : ''));
     } catch (error: any) {
       console.log(error);
 

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,4 +1,3 @@
-import { isPassKeyAvailable } from '@near-js/biometric-ed25519';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
@@ -35,22 +34,6 @@ const SignUpPage: NextPageWithLayout = () => {
   } = useForm();
   const formValues = watch();
   const signedIn = useAuthStore((store) => store.signedIn);
-
-  useEffect(() => {
-    const checkPassKey = async (): Promise<void> => {
-      const isPasskeyReady = await isPassKeyAvailable();
-      if (!isPasskeyReady) {
-        openToast({
-          title: '',
-          type: 'INFO',
-          description:
-            'Passkey support is required for account creation. Try using an updated version of Chrome or Safari to create an account.',
-          duration: 5000,
-        });
-      }
-    };
-    checkPassKey();
-  }, []);
 
   // redirect to home upon signing in
   useEffect(() => {
@@ -105,9 +88,9 @@ const SignUpPage: NextPageWithLayout = () => {
       const fullAccountId = `${data.username}.${network.fastAuth.accountIdSuffix}`;
       const { publicKey, accountId, email } = await handleCreateAccount(fullAccountId, data.email, false);
       router.push(
-        `/verify-email?publicKey=${encodeURIComponent(publicKey)}&accountId=${encodeURIComponent(
+        `/verify-email?accountId=${encodeURIComponent(
           accountId,
-        )}&email=${encodeURIComponent(email)}`,
+        )}&email=${encodeURIComponent(email)}` + (publicKey ? `&publicKey=${encodeURIComponent(publicKey)}` : ''),
       );
     } catch (error: any) {
       openToast({

--- a/src/pages/verify-email.tsx
+++ b/src/pages/verify-email.tsx
@@ -25,15 +25,13 @@ const VerifyEmailPage: NextPageWithLayout = () => {
     if (
       accountRequiredButNotThere ||
       typeof query.email !== 'string' ||
-      !query.email.length ||
-      typeof query.publicKey !== 'string' ||
-      !query.publicKey.length
+      !query.email.length
     )
       return;
 
     try {
       await sendSignInLinkToEmail(firebaseAuth, query.email, {
-        url: `${window.location.origin}/auth-callback?publicKey=${query.publicKey}&accountId=${query.accountId}`,
+        url: `${window.location.origin}/auth-callback?accountId=${query.accountId}` + (query.publicKey ? `&publicKey=${encodeURIComponent(query.publicKey as string)}` : ''),
         handleCodeInApp: true,
       });
       openToast({

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,4 +1,4 @@
-import { createKey } from '@near-js/biometric-ed25519';
+import { createKey, isPassKeyAvailable } from '@near-js/biometric-ed25519';
 import { sendSignInLinkToEmail } from 'firebase/auth';
 import { base_encode } from 'near-api-js/lib/utils/serialize';
 
@@ -22,10 +22,11 @@ export const getCorrectAccessKey = async (userName, firstKeyPair, secondKeyPair)
 };
 
 export const handleCreateAccount = async (accountId, email, isRecovery) => {
-  const keyPair = await createKey(email);
-  const publicKey = keyPair.getPublicKey().toString();
+  const passKeyAvailable = await isPassKeyAvailable();
+  const keyPair = passKeyAvailable && await createKey(email);
+  const publicKey = keyPair && keyPair.getPublicKey().toString();
 
-  if (!publicKey) {
+  if (passKeyAvailable && !publicKey) {
     throw new Error('No public key found');
   }
 
@@ -36,8 +37,8 @@ export const handleCreateAccount = async (accountId, email, isRecovery) => {
   window.localStorage.setItem('fast-auth:account-creation-data', JSON.stringify(accountDataStash));
   await sendSignInLinkToEmail(firebaseAuth, email, {
     url: encodeURI(
-      `${window.location.origin}/auth-callback?publicKey=${publicKey}&accountId=${accountId}` +
-        (isRecovery ? '&isRecovery=true' : ''),
+      `${window.location.origin}/auth-callback?accountId=${accountId}` +
+        (isRecovery ? '&isRecovery=true' : '') + (publicKey ? `&publicKey=${publicKey}` : ''), 
     ),
     handleCodeInApp: true,
   });


### PR DESCRIPTION
Implement limited functionality fallback for non webauthn browsers. Users will be able to use discovery up to the point they need to interact with a non socialDB contract.