### PR TITLE
Adding new web3 chains list and expose setChain

### DIFF
--- a/src/data/web3.ts
+++ b/src/data/web3.ts
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { singletonHook } from 'react-singleton-hook';
 
 import icon from '@/assets/images/near_social_icon.svg';
+import type setChain from '@web3-onboard/core/dist/chain';
 
 const web3onboardKey = 'web3-onboard:connectedWallets';
 
@@ -43,10 +44,16 @@ export const onboard = init({
       rpcUrl: 'https://rpc.ankr.com/eth_goerli',
     },
     {
-      id: '0x4e454152',
+      id: 1313161554,
       token: 'ETH',
       label: 'Aurora Mainnet',
       rpcUrl: 'https://mainnet.aurora.dev',
+    },
+    {
+      id: 1313161555,
+      token: 'ETH',
+      label: 'Aurora Testnet',
+      rpcUrl: 'https://testnet.aurora.dev',
     },
     {
       id: 137,
@@ -57,8 +64,27 @@ export const onboard = init({
     {
       id: 324,
       token: 'ETH',
-      label: 'zkSync',
+      label: 'zkSync Era Mainnet',
       rpcUrl: 'https://zksync2-mainnet.zksync.io',
+    },
+    {
+      id: 1442,
+      token: 'ETH',
+      label: 'Polygon zkEVM Testnet',
+      rpcUrl: 'https://rpc.public.zkevm-test.net',
+    },
+    {
+      id: 42161,
+      token: 'ETH',
+      label: 'Arbitrum One Mainnet',
+      rpcUrl: 'https://arb1.arbitrum.io/rpc',
+    },
+    { id: 10, token: 'ETH', label: 'Optimism', rpcUrl: 'https://rpc.ankr.com/optimism' },
+    {
+      id: 420,
+      token: 'ETH',
+      label: 'Optimism Goerli Testnet',
+      rpcUrl: 'https://optimism-goerli.publicnode.com',
     },
     {
       id: 56,
@@ -67,10 +93,94 @@ export const onboard = init({
       rpcUrl: 'https://bsc.publicnode.com',
     },
     {
-      id: 42161,
+      id: 97,
+      token: 'tBNB',
+      label: 'Binance Smart Chain Testnet',
+      rpcUrl: 'https://bsc-testnet.publicnode.com',
+    },
+    {
+      id: 42170,
       token: 'ETH',
-      label: 'Arbitrum One Mainnet',
-      rpcUrl: 'https://endpoints.omniatech.io/v1/arbitrum/one/public',
+      label: 'Arbitrum Nova',
+      rpcUrl: 'https://nova.arbitrum.io/rpc',
+    },
+    {
+      id: 421613,
+      token: 'AGOR',
+      label: 'Arbitrum Goerli',
+      rpcUrl: 'https://goerli-rollup.arbitrum.io/rpc',
+    },
+    {
+      id: 25,
+      token: 'CRO',
+      label: 'Cronos Mainnet Beta',
+      rpcUrl: 'https://evm.cronos.org',
+    },
+    {
+      id: 338,
+      token: 'TCRO',
+      label: 'Cronos Testnet',
+      rpcUrl: 'https://evm-t3.cronos.org',
+    },
+    {
+      id: 100,
+      token: 'XDAI',
+      label: 'Gnosis',
+      rpcUrl: 'https://rpc.ankr.com/gnosis',
+    },
+    {
+      id: 10200,
+      token: 'XDAI',
+      label: 'Gnosis Chiado Testnet',
+      rpcUrl: 'https://rpc.chiadochain.net',
+    },
+    {
+      id: 42220,
+      token: 'CELO',
+      label: 'Celo Mainnet',
+      rpcUrl: 'https://rpc.ankr.com/celo',
+    },
+    {
+      id: 44787,
+      token: 'CELO',
+      label: 'Celo Alfajores Testnet',
+      rpcUrl: 'https://alfajores-forno.celo-testnet.org',
+    },
+    {
+      id: 43114,
+      token: 'AVAX',
+      label: 'Avalanche C-Chain',
+      rpcUrl: 'https://rpc.ankr.com/avalanche',
+    },
+    {
+      id: 43113,
+      token: 'AVAX',
+      label: 'Avalanche Fuji Testnet',
+      rpcUrl: 'https://rpc.ankr.com/avalanche_fuji',
+    },
+    {
+      id: 250,
+      token: 'FTM',
+      label: 'Fantom Opera',
+      rpcUrl: 'https://rpc.ankr.com/fantom',
+    },
+    {
+      id: 4002,
+      token: 'FTM',
+      label: 'Fantom Testnet',
+      rpcUrl: 'https://rpc.ankr.com/fantom_testnet',
+    },
+    {
+      id: 1284,
+      token: 'GLMR',
+      label: 'Moonbeam',
+      rpcUrl: 'https://rpc.ankr.com/moonbeam',
+    },
+    {
+      id: 61,
+      token: 'ETC',
+      label: 'Ethereum Classic Mainnet',
+      rpcUrl: 'https://etc.rivet.link',
     },
   ],
   appMetadata: {
@@ -88,9 +198,10 @@ export const onboard = init({
 type EthersProviderContext = {
   provider?: EIP1193Provider;
   useConnectWallet: typeof useConnectWallet;
+  setChain: typeof setChain;
 };
 
-const defaultEthersProviderContext: EthersProviderContext = { useConnectWallet };
+const defaultEthersProviderContext: EthersProviderContext = { useConnectWallet, setChain: onboard.setChain };
 
 export const useEthersProviderContext = singletonHook(defaultEthersProviderContext, () => {
   const [{ wallet }] = useConnectWallet();
@@ -129,6 +240,7 @@ export const useEthersProviderContext = singletonHook(defaultEthersProviderConte
     setEthersProvider({
       provider: wallet.provider,
       useConnectWallet,
+      setChain: onboard.setChain,
     });
   }, [wallet]);
 

--- a/src/data/web3.ts
+++ b/src/data/web3.ts
@@ -58,8 +58,20 @@ export const onboard = init({
     {
       id: 137,
       token: 'MATIC',
-      label: 'Matic Mainnet',
+      label: 'Polygon Mainnet',
       rpcUrl: 'https://rpc.ankr.com/polygon',
+    },
+    {
+      id: 80001,
+      token: 'MATIC',
+      label: 'Polygon Testnet Mumbai',
+      rpcUrl: 'https://rpc.ankr.com/polygon_mumbai',
+    },
+    {
+      id: 280,
+      token: 'ETH',
+      label: 'zkSync Era Testnet',
+      rpcUrl: 'https://testnet.era.zksync.dev',
     },
     {
       id: 324,
@@ -85,6 +97,18 @@ export const onboard = init({
       token: 'ETH',
       label: 'Optimism Goerli Testnet',
       rpcUrl: 'https://optimism-goerli.publicnode.com',
+    },
+    {
+      id: 1101,
+      token: 'ETH',
+      label: 'Polygon zkEVM',
+      rpcUrl: 'https://zkevm-rpc.com',
+    },
+    {
+      id: 1442,
+      token: 'ETH',
+      label: 'Polygon zkEVM Testnet',
+      rpcUrl: 'https://rpc.public.zkevm-test.net',
     },
     {
       id: 56,
@@ -181,6 +205,30 @@ export const onboard = init({
       token: 'ETC',
       label: 'Ethereum Classic Mainnet',
       rpcUrl: 'https://etc.rivet.link',
+    },
+    {
+      id: 84531,
+      token: 'ETH',
+      label: 'Base Goerli Testnet',
+      rpcUrl: 'https://goerli.base.org',
+    },
+    {
+      id: 8453,
+      token: 'ETH',
+      label: 'Base',
+      rpcUrl: 'https://mainnet.base.org',
+    },
+    {
+      id: 5001,
+      token: 'MNT',
+      label: 'Mantle Testnet',
+      rpcUrl: 'https://rpc.testnet.mantle.xyz',
+    },
+    {
+      id: 5000,
+      token: 'MNT',
+      label: 'Mantle',
+      rpcUrl: 'https://rpc.mantle.xyz',
     },
   ],
   appMetadata: {


### PR DESCRIPTION
Ports [this PR](https://github.com/NearSocial/viewer/commit/72ef6d08f649cd8f70c4543c8b858b7074fbf526) from near.social

Closes https://github.com/near/near-discovery/issues/325

- Update new EVM chains to the list of chains for Web3Onboard.
- Expose `setChain` to the `VM` through `EthersProviderContext`