### PR TITLE
Algolia Search Proxy Endpoint

### DIFF
--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    if (!process.env.ALGOLIA_ENDPOINT || !process.env.ALGOLIA_API_KEY || !process.env.ALGOLIA_APP_ID) {
+      throw new Error('Invalid algolia search environment variables');
+    }
+
+    const request = await fetch(process.env.ALGOLIA_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Algolia-Api-Key': process.env.ALGOLIA_API_KEY,
+        'X-Algolia-Application-Id': process.env.ALGOLIA_APP_ID,
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await request.json();
+    res.status(request.status).json(data);
+  } catch (error: any) {
+    res.status(500).json({
+      message: error?.message || 'Unknown error',
+    });
+  }
+};
+
+export default handler;


### PR DESCRIPTION
Closes: https://pagodaplatform.atlassian.net/browse/DEC-1402

After talking with @pkudinov, we agreed that it made sense to implement a proxy endpoint `POST /api/search` that can be used by VM components - this will hide the secrets from the frontend. The "App Store" will be the first feature using this endpoint to support searching for apps.

Inside a VM component, you can access the search endpoint:

```
asyncFetch("/api/search", {
    body: JSON.stringify(body),
    headers: {
      "Content-Type": "application/json",
    },
    method: "POST",
  }).then(...).catch(...);
```

I've already gone ahead and added the new ENV variables to Vercel for all of our gateway environments. Right now there's only a MAINNET indexer, but we can easily update the `beta.near.org` ENV variables to use a `TESTNET` version whenever it's ready.