### PR TITLE
Notifications - handle Turn On action

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,41 @@
+const applicationServerKey = '';
+const HOST = '/subscriptions/create';
+
+export const isNotificationSupported = () => typeof window !== 'undefined' && 'Notification' in window;
+
+export const isPushManagerSupported = () => typeof window !== 'undefined' && 'PushManager' in window;
+
+export const isPermisionGranted = () => Notification.permission === 'granted';
+
+const handleRequestPermission = () => Notification.requestPermission();
+
+const registerServiceWorker = () => navigator.serviceWorker.register('/service-worker.js');
+
+const handlePushManagerSubscribe = async () => {
+  const serviceWorker = await navigator.serviceWorker.ready;
+
+  return await serviceWorker.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey,
+  });
+};
+
+const sendToPushServer = (subscriptionData: object) =>
+  fetch(HOST, {
+    method: 'POST',
+    body: JSON.stringify(subscriptionData),
+  });
+
+export const handleTurnOn = async (accountId: string) => {
+  if (!isNotificationSupported() && !isPushManagerSupported() && isPermisionGranted()) {
+    return;
+  }
+
+  await handleRequestPermission();
+  await registerServiceWorker();
+  const subscription = await handlePushManagerSubscribe();
+  await sendToPushServer({
+    subscription,
+    accountId,
+  });
+};


### PR DESCRIPTION
This is the full implementation of the process of enabling push notifications:
 - `isNotificationSupported`, `isPushManagerSupported`, `isPermisionGranted` will help manage the UI, and prevent redundant requests
 - `handleRequestPermission` - first thing that needs to be done is request permission from the user
 - `registerServiceWorker` - next we are registering service worker
 - `handlePushManagerSubscribe` - next we wait for the service worker to be ready and subscribe user - this gives us `subscription` object
 - `sendToPushServer` - sending `subscription` abject and `accountId` to push server.