### PR TITLE
Fixing getXPath() when parent node does not exist

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -154,7 +154,8 @@ function getXPath(element: HTMLElement | null): string {
   if (element === document.body) return element.tagName;
 
   let ix = 0;
-  const siblings = element.parentNode?.children || new HTMLCollection();
+  const siblings = element.parentNode?.children;
+  if (!siblings) return '';
 
   for (let i = 0; i < siblings.length; i++) {
     const sibling = siblings[i];


### PR DESCRIPTION
It turns out that `new HTMLCollection()` is invalid JavaScript. We just need to handle the case when `element.parentNode` is undefined with an early return.