### PR TITLE
add pnpm as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Setup & Development
 
+_This repo requires [pnpm](https://pnpm.io/installation)._
+
 Initialize repo:
 
 ```


### PR DESCRIPTION
I tried using `npm` to initialize and run this project as I assumed `pnpm` was an opinionated choice in this README similar to seeing `yarn` commands. When running `npm i` & `npm run dev` the scripts "appear" to work and deploys a semi-working site via `localhost`. There _are_ some unusual errors in the banner that are resolved after installing & using `pnpm`. 

This PR ads `pnpm` as a requirement in the project's README with a link to the installation docs. Hopefully this will prevent others from performing the same assumption mistake I did. 