### PR TITLE
Hide notifications preview on mobile

### DIFF
--- a/src/components/navigation/NotificationButton.tsx
+++ b/src/components/navigation/NotificationButton.tsx
@@ -11,7 +11,11 @@ import {
 } from '@/utils/notificationsHelpers';
 import { getNotificationLocalStorage } from '@/utils/notificationsLocalStorage';
 
-export function NotificationButton() {
+type Props = {
+  mobileView?: boolean;
+};
+
+export function NotificationButton(props: Props) {
   const components = useBosComponents();
 
   return (
@@ -26,6 +30,7 @@ export function NotificationButton() {
         getNotificationLocalStorage,
         handleOnCancelBanner,
         handleTurnOn,
+        mobileView: props.mobileView ?? false,
       }}
     />
   );

--- a/src/components/navigation/mobile/MenuLeft.tsx
+++ b/src/components/navigation/mobile/MenuLeft.tsx
@@ -182,7 +182,7 @@ export function MenuLeft(props: Props) {
         )}
         {signedIn && (
           <div className="logged-in-btns">
-            <NotificationButton />
+            <NotificationButton mobileView={true} />
             <UserDropdownMenu />
           </div>
         )}

--- a/src/components/navigation/mobile/MenuLeft.tsx
+++ b/src/components/navigation/mobile/MenuLeft.tsx
@@ -93,20 +93,13 @@ const StyledMenu = styled.div`
     margin-top: auto;
     display: flex;
 
-    .nav-notification-button {
-      margin: 0;
-      min-width: 46px;
-      min-height: 46px;
-      margin-right: 20px;
-
-      a {
+    & > div {
+      &:first-child {
+        margin: 0 20px 0 0;
         min-width: 46px;
         min-height: 46px;
       }
-    }
-
-    > div {
-      :nth-child(2) {
+      &:nth-child(2) {
         width: fill-available;
         > button {
           width: 100%;


### PR DESCRIPTION
At this moment when you click on notification button on mobile you'll see a preview with notifications for a while. This is wrong and was discussed [here](https://pagodaplatform.atlassian.net/browse/DEC-1431).

`mobileView` is added is this [PR](https://github.com/near/near-discovery-components/pull/349).