### PR TITLE
fix: broken legacy /validators link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,11 @@ const nextConfig = {
         permanent: false,
       },
       {
+        source: '/validators',
+        destination: 'https://pages.near.org/validators',
+        permanent: true,
+      },
+      {
         source: '/edit/:path*',
         destination: '/sandbox/:path*',
         permanent: true,


### PR DESCRIPTION
redirects to https://pages.near.org/about/network/validators/