### PR TITLE
Add note about minimal required iOS version

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,14 @@ import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useCurrentComponentStore } from '@/stores/current-component';
-import { handleOnCancel, handleTurnOn, isIOS, showNotificationModal } from '@/utils/notifications';
+import {
+  detestIOSVersion,
+  handleOnCancel,
+  handleTurnOn,
+  isIOS,
+  recomendedIOSVersion,
+  showNotificationModal,
+} from '@/utils/notifications';
 import { isNotificationSupported, isPermisionGranted, isPushManagerSupported } from '@/utils/notificationsHelpers';
 import { getNotificationLocalStorage, setNotificationsSessionStorage } from '@/utils/notificationsLocalStorage';
 import type { NextPageWithLayout, TosData } from '@/utils/types';
@@ -38,6 +45,13 @@ const HomePage: NextPageWithLayout = () => {
     }
     return false;
   }, []);
+
+  const iOSVersion = useMemo(() => {
+    if (typeof window !== 'undefined' && iOSDevice) {
+      return detestIOSVersion();
+    }
+    return;
+  }, [iOSDevice]);
 
   const handleModalCloseOnEsc = useCallback(() => {
     setShowNotificationModalState(false);
@@ -148,6 +162,8 @@ const HomePage: NextPageWithLayout = () => {
             setNotificationsSessionStorage,
             onOpenChange: handleModalCloseOnEsc,
             iOSDevice,
+            iOSVersion,
+            recomendedIOSVersion,
           }}
         />
         <VmComponent

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useCurrentComponentStore } from '@/stores/current-component';
 import {
-  detestIOSVersion,
+  detectIOSVersion,
   handleOnCancel,
   handleTurnOn,
   isIOS,
@@ -48,7 +48,7 @@ const HomePage: NextPageWithLayout = () => {
 
   const iOSVersion = useMemo(() => {
     if (typeof window !== 'undefined' && iOSDevice) {
-      return detestIOSVersion();
+      return detectIOSVersion();
     }
     return;
   }, [iOSDevice]);

--- a/src/pages/notifications-settings.tsx
+++ b/src/pages/notifications-settings.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
@@ -7,6 +9,7 @@ import {
   handleOnCancelBanner,
   handlePushManagerUnsubscribe,
   handleTurnOn,
+  isIOS,
 } from '@/utils/notifications';
 import {
   isLocalStorageSupported,
@@ -20,6 +23,12 @@ import type { NextPageWithLayout } from '@/utils/types';
 const NotificationsSettingsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
   const accountId = useAuthStore((store) => store.accountId);
+  const iOSDevice = useMemo(() => {
+    if (typeof window !== 'undefined') {
+      return isIOS();
+    }
+    return false;
+  }, []);
 
   return (
     <ComponentWrapperPage
@@ -37,6 +46,7 @@ const NotificationsSettingsPage: NextPageWithLayout = () => {
         accountId,
         handleTurnOn,
         handlePushManagerUnsubscribe,
+        iOSDevice,
       }}
     />
   );

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -5,7 +5,7 @@ import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import {
-  detestIOSVersion,
+  detectIOSVersion,
   handleOnCancel,
   handleOnCancelBanner,
   handleTurnOn,
@@ -33,7 +33,7 @@ const NotificationsPage: NextPageWithLayout = () => {
 
   const iOSVersion = useMemo(() => {
     if (typeof window !== 'undefined' && iOSDevice) {
-      return detestIOSVersion();
+      return detectIOSVersion();
     }
     return;
   }, [iOSDevice]);

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -1,8 +1,17 @@
+import { useMemo } from 'react';
+
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
-import { handleOnCancel, handleOnCancelBanner, handleTurnOn } from '@/utils/notifications';
+import {
+  detestIOSVersion,
+  handleOnCancel,
+  handleOnCancelBanner,
+  handleTurnOn,
+  isIOS,
+  recomendedIOSVersion,
+} from '@/utils/notifications';
 import {
   isLocalStorageSupported,
   isNotificationSupported,
@@ -15,6 +24,19 @@ import type { NextPageWithLayout } from '@/utils/types';
 const NotificationsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
   const accountId = useAuthStore((store) => store.accountId);
+  const iOSDevice = useMemo(() => {
+    if (typeof window !== 'undefined') {
+      return isIOS();
+    }
+    return false;
+  }, []);
+
+  const iOSVersion = useMemo(() => {
+    if (typeof window !== 'undefined' && iOSDevice) {
+      return detestIOSVersion();
+    }
+    return;
+  }, [iOSDevice]);
 
   return (
     <ComponentWrapperPage
@@ -31,6 +53,9 @@ const NotificationsPage: NextPageWithLayout = () => {
         handleOnCancelBanner,
         accountId,
         handleTurnOn,
+        iOSDevice,
+        iOSVersion,
+        recomendedIOSVersion,
       }}
     />
   );

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -20,6 +20,9 @@ const applicationServerKey = 'BH_QFHjBU9x3VlmE9_XM4Awhm5vj2wF9WNQIz5wdlO6hc5anwE
 const HOST = 'https://discovery-notifications-mainnet.near.org';
 const GATEWAY_URL = 'https://near.org';
 
+// min version for iOS to support notifications
+export const recomendedIOSVersion = 16.4;
+
 export const isIOS = () => {
   const browserInfo = navigator.userAgent.toLowerCase();
 
@@ -28,6 +31,24 @@ export const isIOS = () => {
     browserInfo.includes('ipad') ||
     ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(navigator.platform)
   );
+};
+
+export const detestIOSVersion = () => {
+  const userAgent = navigator.userAgent;
+  const iOSVersionMatch = userAgent.match(/iPhone|iPad|iPod/i);
+  let iOSVersion;
+  if (iOSVersionMatch) {
+    // Extract the iOS version from the user agent
+    const iOSVersionString = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
+    if (iOSVersionString) {
+      const versionParts = iOSVersionString
+        .slice(1)
+        .filter((i) => i !== undefined)
+        .map(Number);
+      iOSVersion = Number(versionParts.map(Number).join('.'));
+    }
+  }
+  return iOSVersion;
 };
 
 const handleRequestPermission = () => Notification.requestPermission();

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -33,7 +33,7 @@ export const isIOS = () => {
   );
 };
 
-export const detestIOSVersion = () => {
+export const detectIOSVersion = () => {
   const userAgent = navigator.userAgent;
   const iOSVersionMatch = userAgent.match(/iPhone|iPad|iPod/i);
   let iOSVersion;


### PR DESCRIPTION
Closes [#667](https://github.com/near/near-discovery/issues/667)

This PR introduces a note about minimal iOS version for notifications feature. This note depends on iOS device and it's version which means that android users won't see this note. Also if iOS device has it's version > minimal version -> we don't show such note