### PR TITLE
Fix Notifications Infinite "NaN" Loop

### DIFF
--- a/src/components/NotificationsAlert.tsx
+++ b/src/components/NotificationsAlert.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { VmComponent } from '@/components/vm/VmComponent';
+import { useBosComponents } from '@/hooks/useBosComponents';
+import { useIosDevice } from '@/hooks/useIosDevice';
+import { useAuthStore } from '@/stores/auth';
+import {
+  handleOnCancel,
+  handleTurnOn,
+  recommendedIosVersionForNotifications,
+  showNotificationModal,
+} from '@/utils/notifications';
+import { isNotificationSupported, isPermisionGranted, isPushManagerSupported } from '@/utils/notificationsHelpers';
+import { getNotificationLocalStorage, setNotificationsSessionStorage } from '@/utils/notificationsLocalStorage';
+import type { TosData } from '@/utils/types';
+
+type Props = {
+  tosData: TosData | null;
+};
+
+export const NotificationsAlert = ({ tosData }: Props) => {
+  const signedIn = useAuthStore((store) => store.signedIn);
+  const components = useBosComponents();
+  const [showNotificationModalState, setShowNotificationModalState] = useState(false);
+  const accountId = useAuthStore((store) => store.accountId);
+  const [isHomeScreenApp, setHomeScreenApp] = useState(false);
+  const [iosHomeScreenPrompt, setIosHomeScreenPrompt] = useState(false);
+  const { isIosDevice, versionOfIos } = useIosDevice();
+
+  const handleModalCloseOnEsc = useCallback(() => {
+    setShowNotificationModalState(false);
+  }, []);
+
+  const handleHomeScreenClose = useCallback(() => {
+    setIosHomeScreenPrompt(false);
+  }, []);
+
+  const turnNotificationsOn = useCallback(() => {
+    // for iOS devices, show a different modal asking the user to add the app to their home screen
+    // if the user has already added the app to their home screen, show the regular notification modal
+    if (isIosDevice && !isHomeScreenApp) {
+      setIosHomeScreenPrompt(true);
+      setShowNotificationModalState(false);
+      return;
+    }
+    return handleTurnOn(accountId, () => {
+      setShowNotificationModalState(false);
+    });
+  }, [accountId, isIosDevice, isHomeScreenApp]);
+
+  const pauseNotifications = useCallback(() => {
+    handleOnCancel();
+    setShowNotificationModalState(false);
+  }, []);
+
+  const checkNotificationModal = useCallback(() => {
+    if (tosData && tosData.agreementsForUser.length > 0) {
+      // show notification modal for new users
+      const tosAccepted =
+        tosData.agreementsForUser[tosData.agreementsForUser.length - 1].value === tosData.latestTosVersion;
+      // check if user has already turned on notifications
+      const { showOnTS } = getNotificationLocalStorage() || {};
+
+      if (!iosHomeScreenPrompt && ((tosAccepted && !showOnTS) || (tosAccepted && showOnTS < Date.now()))) {
+        setTimeout(() => {
+          setShowNotificationModalState(showNotificationModal());
+        }, 3000);
+      }
+    }
+  }, [tosData, iosHomeScreenPrompt]);
+
+  useEffect(() => {
+    if (!signedIn) {
+      return;
+    }
+    checkNotificationModal();
+  }, [signedIn, checkNotificationModal]);
+
+  useEffect(() => {
+    if (isIosDevice) {
+      setHomeScreenApp(window.matchMedia('(display-mode: standalone)').matches);
+    }
+  }, [isIosDevice]);
+
+  useEffect(() => {
+    if (isIosDevice) {
+      window.matchMedia('(display-mode: standalone)').addEventListener('change', (e) => setHomeScreenApp(e.matches));
+      // TODO: Remove event listener on cleanup
+    }
+  }, [isIosDevice]);
+
+  if (!signedIn) return null;
+
+  return (
+    <>
+      <VmComponent
+        src={components.nearOrg.notifications.alert}
+        props={{
+          open: showNotificationModalState,
+          handleTurnOn: turnNotificationsOn,
+          handleOnCancel: pauseNotifications,
+          isNotificationSupported,
+          isPermisionGranted,
+          isPushManagerSupported,
+          setNotificationsSessionStorage,
+          onOpenChange: handleModalCloseOnEsc,
+          iOSDevice: isIosDevice,
+          iOSVersion: versionOfIos,
+          recomendedIOSVersion: recommendedIosVersionForNotifications,
+        }}
+      />
+      <VmComponent
+        src={components.nearOrg.notifications.iosHomeScreenAlert}
+        props={{
+          open: iosHomeScreenPrompt,
+          onOpenChange: handleHomeScreenClose,
+        }}
+      />
+    </>
+  );
+};

--- a/src/hooks/useBosLoaderInitializer.ts
+++ b/src/hooks/useBosLoaderInitializer.ts
@@ -52,8 +52,9 @@ export function useBosLoaderInitializer() {
   useEffect(() => {
     if (loaderUrl) {
       fetchRedirectMap(loaderUrl);
-    } else {
+    } else if (flags) {
+      // We need to check if "flags" has fully resolved to avoid prematurely setting "hasResolved: true"
       setStore({ hasResolved: true });
     }
-  }, [fetchRedirectMap, loaderUrl, setStore]);
+  }, [flags, fetchRedirectMap, loaderUrl, setStore]);
 }

--- a/src/hooks/useIosDevice.ts
+++ b/src/hooks/useIosDevice.ts
@@ -1,0 +1,34 @@
+function detectIos() {
+  if (typeof window === 'undefined') return;
+
+  const isIosDevice = /iP(hone|od|ad)/.test(navigator.userAgent);
+  let versionOfIos = 0;
+
+  const versionMatch = navigator.userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
+
+  if (versionMatch) {
+    versionOfIos = Number(`${versionMatch[1]}.${versionMatch[2]}`);
+
+    if (isNaN(versionOfIos)) {
+      /*
+        We need to ensure that we never return "NaN". It isn't referentially stable and
+        causes infinite loops inside logic like useEffect().
+      */
+      versionOfIos = 0;
+    }
+  }
+
+  return {
+    isIosDevice,
+    versionOfIos,
+  };
+}
+
+export function useIosDevice() {
+  const result = detectIos();
+
+  return {
+    isIosDevice: result?.isIosDevice,
+    versionOfIos: result?.versionOfIos,
+  };
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,26 +1,16 @@
 import { isPassKeyAvailable } from '@near-js/biometric-ed25519';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { openToast } from '@/components/lib/Toast';
 import { MetaTags } from '@/components/MetaTags';
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { NearOrgHomePage } from '@/components/near-org/NearOrg.HomePage';
-import { VmComponent } from '@/components/vm/VmComponent';
+import { NotificationsAlert } from '@/components/NotificationsAlert';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useCurrentComponentStore } from '@/stores/current-component';
-import {
-  detectIOSVersion,
-  handleOnCancel,
-  handleTurnOn,
-  isIOS,
-  recomendedIOSVersion,
-  showNotificationModal,
-} from '@/utils/notifications';
-import { isNotificationSupported, isPermisionGranted, isPushManagerSupported } from '@/utils/notificationsHelpers';
-import { getNotificationLocalStorage, setNotificationsSessionStorage } from '@/utils/notificationsLocalStorage';
 import type { NextPageWithLayout, TosData } from '@/utils/types';
 
 const LS_ACCOUNT_ID = 'near-social-vm:v01::accountId:';
@@ -33,75 +23,8 @@ const HomePage: NextPageWithLayout = () => {
   const setComponentSrc = useCurrentComponentStore((store) => store.setSrc);
   const authStore = useAuthStore();
   const [componentProps, setComponentProps] = useState<Record<string, unknown>>({});
-  const [showNotificationModalState, setShowNotificationModalState] = useState(false);
-  const accountId = useAuthStore((store) => store.accountId);
   const [tosData, setTosData] = useState<TosData | null>(null);
-  const cacheTosData = useMemo(() => tosData, [tosData?.latestTosVersion]);
-  const [isHomeScreenApp, setHomeScreenApp] = useState(false);
-  const [iosHomeScreenPrompt, setIosHomeScreenPrompt] = useState(false);
-  const iOSDevice = useMemo(() => {
-    if (typeof window !== 'undefined') {
-      return isIOS();
-    }
-    return false;
-  }, []);
-
-  const iOSVersion = useMemo(() => {
-    if (typeof window !== 'undefined' && iOSDevice) {
-      return detectIOSVersion();
-    }
-    return;
-  }, [iOSDevice]);
-
-  const handleModalCloseOnEsc = useCallback(() => {
-    setShowNotificationModalState(false);
-  }, []);
-
-  const handleHomeScreenClose = useCallback(() => {
-    setIosHomeScreenPrompt(false);
-  }, []);
-
-  const turnNotificationsOn = useCallback(() => {
-    // for iOS devices, show a different modal asking the user to add the app to their home screen
-    // if the user has already added the app to their home screen, show the regular notification modal
-    if (iOSDevice && !isHomeScreenApp) {
-      setIosHomeScreenPrompt(true);
-      setShowNotificationModalState(false);
-      return;
-    }
-    return handleTurnOn(accountId, () => {
-      setShowNotificationModalState(false);
-    });
-  }, [accountId, iOSDevice, isHomeScreenApp]);
-
-  const pauseNotifications = useCallback(() => {
-    handleOnCancel();
-    setShowNotificationModalState(false);
-  }, []);
-
-  const checkNotificationModal = useCallback(() => {
-    if (cacheTosData && cacheTosData.agreementsForUser.length > 0) {
-      // show notification modal for new users
-      const tosAccepted =
-        cacheTosData.agreementsForUser[cacheTosData.agreementsForUser.length - 1].value ===
-        cacheTosData.latestTosVersion;
-      // check if user has already turned on notifications
-      const { showOnTS } = getNotificationLocalStorage() || {};
-
-      if (!iosHomeScreenPrompt && ((tosAccepted && !showOnTS) || (tosAccepted && showOnTS < Date.now()))) {
-        setTimeout(() => {
-          setShowNotificationModalState(showNotificationModal());
-        }, 3000);
-      }
-    }
-  }, [cacheTosData, iosHomeScreenPrompt]);
-
-  useEffect(() => {
-    if (!signedIn) {
-      return;
-    }
-    checkNotificationModal();
-  }, [signedIn, checkNotificationModal]);
+  const cachedTosData = useMemo(() => tosData, [tosData?.latestTosVersion]);
 
   useEffect(() => {
     const optimisticAccountId = window.localStorage.getItem(LS_ACCOUNT_ID);
@@ -114,8 +37,8 @@ const HomePage: NextPageWithLayout = () => {
     }
   }, [signedIn, setComponentSrc]);
 
-  // if we are loading the ActivityPage, process the query params into componentProps
   useEffect(() => {
+    // If we are loading the ActivityPage, process the query params into componentProps
     if (signedIn || signedInOptimistic) {
       setComponentProps(router.query);
     }
@@ -135,44 +58,12 @@ const HomePage: NextPageWithLayout = () => {
       });
     }
   }, [signedIn]);
-  useEffect(() => {
-    if (iOSDevice) {
-      setHomeScreenApp(window.matchMedia('(display-mode: standalone)').matches);
-    }
-  }, [iOSDevice]);
-
-  useEffect(() => {
-    if (iOSDevice) {
-      window.matchMedia('(display-mode: standalone)').addEventListener('change', (e) => setHomeScreenApp(e.matches));
-    }
-  }, [iOSDevice]);
 
   if (signedIn || signedInOptimistic) {
     return (
       <>
-        <VmComponent
-          src={components.nearOrg.notifications.alert}
-          props={{
-            open: showNotificationModalState,
-            handleTurnOn: turnNotificationsOn,
-            handleOnCancel: pauseNotifications,
-            isNotificationSupported,
-            isPermisionGranted,
-            isPushManagerSupported,
-            setNotificationsSessionStorage,
-            onOpenChange: handleModalCloseOnEsc,
-            iOSDevice,
-            iOSVersion,
-            recomendedIOSVersion,
-          }}
-        />
-        <VmComponent
-          src={components.nearOrg.notifications.iosHomeScreenAlert}
-          props={{
-            open: iosHomeScreenPrompt,
-            onOpenChange: handleHomeScreenClose,
-          }}
-        />
+        <NotificationsAlert tosData={cachedTosData} />
+
         <ComponentWrapperPage
           src={components.tosCheck}
           componentProps={{

--- a/src/pages/notifications-settings.tsx
+++ b/src/pages/notifications-settings.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react';
-
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { useBosComponents } from '@/hooks/useBosComponents';
+import { useIosDevice } from '@/hooks/useIosDevice';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import {
@@ -9,7 +8,6 @@ import {
   handleOnCancelBanner,
   handlePushManagerUnsubscribe,
   handleTurnOn,
-  isIOS,
 } from '@/utils/notifications';
 import {
   isLocalStorageSupported,
@@ -23,18 +21,12 @@ import type { NextPageWithLayout } from '@/utils/types';
 const NotificationsSettingsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
   const accountId = useAuthStore((store) => store.accountId);
-  const iOSDevice = useMemo(() => {
-    if (typeof window !== 'undefined') {
-      return isIOS();
-    }
-    return false;
-  }, []);
+  const { isIosDevice } = useIosDevice();
 
   return (
     <ComponentWrapperPage
       src={components.nearOrg.notifications.settings}
-      // TODO: fill
-      meta={{ title: '', description: '' }}
+      meta={{ title: 'NEAR | Notification Settings', description: '' }}
       componentProps={{
         isLocalStorageSupported,
         isNotificationSupported,
@@ -46,7 +38,7 @@ const NotificationsSettingsPage: NextPageWithLayout = () => {
         accountId,
         handleTurnOn,
         handlePushManagerUnsubscribe,
-        iOSDevice,
+        iOSDevice: isIosDevice,
       }}
     />
   );

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -1,16 +1,13 @@
-import { useMemo } from 'react';
-
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { useBosComponents } from '@/hooks/useBosComponents';
+import { useIosDevice } from '@/hooks/useIosDevice';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import {
-  detectIOSVersion,
   handleOnCancel,
   handleOnCancelBanner,
   handleTurnOn,
-  isIOS,
-  recomendedIOSVersion,
+  recommendedIosVersionForNotifications,
 } from '@/utils/notifications';
 import {
   isLocalStorageSupported,
@@ -24,25 +21,12 @@ import type { NextPageWithLayout } from '@/utils/types';
 const NotificationsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
   const accountId = useAuthStore((store) => store.accountId);
-  const iOSDevice = useMemo(() => {
-    if (typeof window !== 'undefined') {
-      return isIOS();
-    }
-    return false;
-  }, []);
-
-  const iOSVersion = useMemo(() => {
-    if (typeof window !== 'undefined' && iOSDevice) {
-      return detectIOSVersion();
-    }
-    return;
-  }, [iOSDevice]);
+  const { isIosDevice, versionOfIos } = useIosDevice();
 
   return (
     <ComponentWrapperPage
       src={components.nearOrg.notifications.page}
-      // TODO: fill
-      meta={{ title: '', description: '' }}
+      meta={{ title: 'NEAR | Notifications', description: '' }}
       componentProps={{
         isLocalStorageSupported,
         isNotificationSupported,
@@ -53,9 +37,9 @@ const NotificationsPage: NextPageWithLayout = () => {
         handleOnCancelBanner,
         accountId,
         handleTurnOn,
-        iOSDevice,
-        iOSVersion,
-        recomendedIOSVersion,
+        iOSDevice: isIosDevice,
+        iOSVersion: versionOfIos,
+        recomendedIOSVersion: recommendedIosVersionForNotifications,
       }}
     />
   );

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -21,35 +21,7 @@ const HOST = 'https://discovery-notifications-mainnet.near.org';
 const GATEWAY_URL = 'https://near.org';
 
 // min version for iOS to support notifications
-export const recomendedIOSVersion = 16.4;
-
-export const isIOS = () => {
-  const browserInfo = navigator.userAgent.toLowerCase();
-
-  return (
-    browserInfo.includes('iphone') ||
-    browserInfo.includes('ipad') ||
-    ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(navigator.platform)
-  );
-};
-
-export const detectIOSVersion = () => {
-  const userAgent = navigator.userAgent;
-  const iOSVersionMatch = userAgent.match(/iPhone|iPad|iPod/i);
-  let iOSVersion;
-  if (iOSVersionMatch) {
-    // Extract the iOS version from the user agent
-    const iOSVersionString = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
-    if (iOSVersionString) {
-      const versionParts = iOSVersionString
-        .slice(1)
-        .filter((i) => i !== undefined)
-        .map(Number);
-      iOSVersion = Number(versionParts.map(Number).join('.'));
-    }
-  }
-  return iOSVersion;
-};
+export const recommendedIosVersionForNotifications = 16.4;
 
 const handleRequestPermission = () => Notification.requestPermission();
 


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery/issues/684

Our previous logic for detecting the iOS version would return `NaN` due to trying parse a number with multiple periods (EG: `Number("16.2.3")`. In JS, `NaN` is not referentially equal to itself, which was causing an infinite loop when used as a `useEffect()` or `useCallback()` dependency.

I broke out all of the notification alert logic from the home page into `<NotificationsAlert />` to help reduce re-renders of the entire activity page.

I also realized that `useBosLoaderInitializer()` was prematurely setting `hasResolved: true` - which would cause `<VmComponent>` to fetch and render code from the blockchain before using the `redirectMap` provided by BOS Loader for local development.

I could use some help thoroughly testing the preview branch @charleslavon to make sure the issue is fully resolved and that I didn't break anything in the process. :)