### PR TITLE
Avoid auto capitalize on FasthAuth sign up page

### DIFF
--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -152,6 +152,7 @@ const SignUpPage: NextPageWithLayout = () => {
                 message: 'Please enter a valid email address',
               },
             })}
+            autoCapitalize="off"
             onChange={(e) => {
               clearErrors('email');
               setValue('email', e.target.value);
@@ -171,6 +172,7 @@ const SignUpPage: NextPageWithLayout = () => {
         <InputContainer>
           <label htmlFor="username">Account ID</label>
           <input
+            autoCapitalize="off"
             autoComplete="webauthn username"
             {...register('username', {
               required: 'Please enter a valid account ID',


### PR DESCRIPTION
Turning auto capitalizing off for email and account id results in improved UX, especially on mobile. Currently while signing up on mobile, the account id input shows an error since the input automatically capitalizes the first letter, which is not a valid account id.