### PR TITLE
chore: Bump VM version to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "local-storage": "^2.0.0",
         "lodash": "^4.17.21",
         "near-fastauth-wallet": "^0.0.8",
-        "near-social-vm": "github:NearSocial/VM#2.4.2",
+        "near-social-vm": "github:NearSocial/VM#2.5.0",
         "next": "13.3.4",
         "prettier": "^2.7.1",
         "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ dependencies:
     specifier: ^0.0.8
     version: 0.0.8
   near-social-vm:
-    specifier: github:NearSocial/VM#2.4.2
-    version: github.com/NearSocial/VM/a6ed652ff5ea296321e8a0eba09239da160cfa7b(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    specifier: github:NearSocial/VM#2.5.0
+    version: github.com/NearSocial/VM/2794f2646e10f6542858df6f7c5ba6beb8755ff8(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
   next:
     specifier: 13.3.4
     version: 13.3.4(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
@@ -10579,11 +10579,11 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
 
-  github.com/NearSocial/VM/a6ed652ff5ea296321e8a0eba09239da160cfa7b(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
-    resolution: {tarball: https://codeload.github.com/NearSocial/VM/tar.gz/a6ed652ff5ea296321e8a0eba09239da160cfa7b}
-    id: github.com/NearSocial/VM/a6ed652ff5ea296321e8a0eba09239da160cfa7b
+  github.com/NearSocial/VM/2794f2646e10f6542858df6f7c5ba6beb8755ff8(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
+    resolution: {tarball: https://codeload.github.com/NearSocial/VM/tar.gz/2794f2646e10f6542858df6f7c5ba6beb8755ff8}
+    id: github.com/NearSocial/VM/2794f2646e10f6542858df6f7c5ba6beb8755ff8
     name: near-social-vm
-    version: 2.4.2
+    version: 2.5.0
     peerDependencies:
       near-api-js: 2.1.3
       react: ^18.2.0


### PR DESCRIPTION
Release changes: https://github.com/NearSocial/VM/releases/tag/2.5.0

This update introduces `useMemo ` and `useCallback` hooks along with other important additions and fixes 