### PR TITLE
Add data component attribute feature

### DIFF
--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -96,6 +96,7 @@ export default function VmInitializer() {
         customElements: {
           Link: ({ href, to, ...rest }: any) => <Link href={sanitizeUrl(href ?? to)} {...rest} />,
         },
+        features: { enableComponentSrcDataKey: true },
       });
   }, [initNear]);
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -106,6 +106,7 @@ const record = (eventType: string, e: UIEvent | PointerEvent) => {
     element: truncate(key, { length: 255 }),
     url: e.target ? filterURL((e.target as HTMLElement).baseURI) : '',
     xPath: getXPath(e.target as HTMLElement),
+    componentSrc: getComponentName(e.target as HTMLElement),
   });
 };
 export const recordClick = (e: UIEvent | PointerEvent) => record('click', e);
@@ -156,6 +157,12 @@ export function recordEvent(eventLabel: string) {
   } catch (e) {
     console.error(e);
   }
+}
+
+function getComponentName(element: HTMLElement | null): string {
+  if (!element) return '';
+  if (element.hasAttribute('data-key')) return element.getAttribute('data-key') || '';
+  return ''
 }
 
 function getXPath(element: HTMLElement | null): string {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -161,7 +161,7 @@ export function recordEvent(eventLabel: string) {
 
 function getComponentName(element: HTMLElement | null): string {
   if (!element) return '';
-  if (element.hasAttribute('data-key')) return element.getAttribute('data-key') || '';
+  if (element.hasAttribute('data-component')) return element.getAttribute('data-component') || '';
   return ''
 }
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -162,7 +162,7 @@ export function recordEvent(eventLabel: string) {
 function getComponentName(element: HTMLElement | null): string {
   if (!element) return '';
   if (element.hasAttribute('data-component')) return element.getAttribute('data-component') || '';
-  return ''
+  return '';
 }
 
 function getXPath(element: HTMLElement | null): string {


### PR DESCRIPTION
Collect Component Interaction events and send them to Rudderstack. 

This PR requires VM release 2.5.0

It enables this feature documented here: https://github.com/NearSocial/VM/pull/131

