### PR TITLE
Upgrade vm  (#720)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "local-storage": "^2.0.0",
         "lodash": "^4.17.21",
         "near-fastauth-wallet": "^0.0.8",
-        "near-social-vm": "github:NearSocial/VM#2.5.0",
+        "near-social-vm": "github:NearSocial/VM#disable-is-tag",
         "next": "13.3.4",
         "prettier": "^2.7.1",
         "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@braintree/sanitize-url':
     specifier: 6.0.0
@@ -120,8 +116,8 @@ dependencies:
     specifier: ^0.0.8
     version: 0.0.8
   near-social-vm:
-    specifier: github:NearSocial/VM#2.5.0
-    version: github.com/NearSocial/VM/2794f2646e10f6542858df6f7c5ba6beb8755ff8(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    specifier: github:NearSocial/VM#disable-is-tag
+    version: github.com/NearSocial/VM/fedc4a2f878e6e75385d4b1e69f37a1b77e739c6(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
   next:
     specifier: 13.3.4
     version: 13.3.4(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
@@ -10579,9 +10575,9 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
 
-  github.com/NearSocial/VM/2794f2646e10f6542858df6f7c5ba6beb8755ff8(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
-    resolution: {tarball: https://codeload.github.com/NearSocial/VM/tar.gz/2794f2646e10f6542858df6f7c5ba6beb8755ff8}
-    id: github.com/NearSocial/VM/2794f2646e10f6542858df6f7c5ba6beb8755ff8
+  github.com/NearSocial/VM/fedc4a2f878e6e75385d4b1e69f37a1b77e739c6(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
+    resolution: {tarball: https://codeload.github.com/NearSocial/VM/tar.gz/fedc4a2f878e6e75385d4b1e69f37a1b77e739c6}
+    id: github.com/NearSocial/VM/fedc4a2f878e6e75385d4b1e69f37a1b77e739c6
     name: near-social-vm
     version: 2.5.0
     peerDependencies:
@@ -10661,3 +10657,7 @@ packages:
       - supports-color
       - utf-8-validate
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
* weekly promotion of develop to main (#324)

* Private and Signed Out routes

* types

* Cleanup after conflicts

* Remove old bundle file

* Update src/utils/route/privateRoute.tsx



* generate opengraph previews for components (#312)

* chore: upgrade @near-js/biometric-ed25519 package (#289)

* feat: allow signIn with only LAK for no webauthn browsers (#308)

* fix: prevent the onboarding modal from flashing and only show the vscode banner during onboarding (#320)

* Update issue templates

* doc: adding contribution guides (#321)

* doc: addting contribution guides

* prettier fix

---------











* chore: update vm

---------