### PR TITLE
Use "App Library" BOS component for /applications page

### DIFF
--- a/src/data/bos-components.ts
+++ b/src/data/bos-components.ts
@@ -1,6 +1,7 @@
 import type { NetworkId } from '@/utils/types';
 
 type NetworkComponents = {
+  applicationsPage: string;
   bosDirectory: string;
   componentSummary: string;
   componentsPage: string;
@@ -50,6 +51,7 @@ type NetworkComponents = {
 export const componentsByNetworkId: Record<NetworkId, NetworkComponents | undefined> = {
   // localnet: undefined,
   testnet: {
+    applicationsPage: 'discom.testnet/widget/AppLibrary.IndexPage',
     bosDirectory: 'one.testnet/widget/BOSDirectory',
     componentSummary: 'discom.testnet/widget/ComponentSummary',
     componentsPage: 'discom.testnet/widget/ComponentsPage',
@@ -97,6 +99,7 @@ export const componentsByNetworkId: Record<NetworkId, NetworkComponents | undefi
   },
 
   mainnet: {
+    applicationsPage: 'near/widget/AppLibrary.IndexPage',
     bosDirectory: 'onboarder.near/widget/BOSDirectory',
     componentSummary: 'near/widget/ComponentSummary',
     componentsPage: 'near/widget/ComponentsPage',

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -8,11 +8,8 @@ const ApplicationsPage: NextPageWithLayout = () => {
 
   return (
     <ComponentWrapperPage
-      src={components.componentsPage}
-      componentProps={{
-        tab: 'apps',
-      }}
-      meta={{ title: 'Applications built on the BOS', description: 'BOS Applications' }}
+      src={components.applicationsPage}
+      meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
     />
   );
 };


### PR DESCRIPTION
Related to: https://github.com/near/near-discovery-components/issues/389

I confirmed with @TiffanyGYJ that we should update the `/applications` route now that we've completed the App Library MVP.