### PR TITLE
Move 'Ready for Development' items to next sprint

### DIFF
--- a/.github/workflows/update-sprint-board.yml
+++ b/.github/workflows/update-sprint-board.yml
@@ -17,4 +17,4 @@ jobs:
         iteration-field: sprint
         iteration: last
         new-iteration: current
-        statuses: None,Selected,Blocked,In Progress,In Review,Todo
+        statuses: None,Selected,Blocked,In Progress,In Review,Todo,Ready for Development


### PR DESCRIPTION
I'm not sure whether Selected is actually the same status or if we caused this issue by renaming Selected to Ready for Development. Seems like no harm in adding it.