### PR TITLE
Fix Activity Page Flashing (Part 2 of 2)

### DIFF
--- a/src/components/NotificationsAlert.tsx
+++ b/src/components/NotificationsAlert.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
+import styled from 'styled-components';
 
 import { VmComponent } from '@/components/vm/VmComponent';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useIosDevice } from '@/hooks/useIosDevice';
 import { useAuthStore } from '@/stores/auth';
+import { useTermsOfServiceStore } from '@/stores/terms-of-service';
 import {
   handleOnCancel,
   handleTurnOn,
@@ -12,13 +14,13 @@ import {
 } from '@/utils/notifications';
 import { isNotificationSupported, isPermisionGranted, isPushManagerSupported } from '@/utils/notificationsHelpers';
 import { getNotificationLocalStorage, setNotificationsSessionStorage } from '@/utils/notificationsLocalStorage';
-import type { TosData } from '@/utils/types';
 
-type Props = {
-  tosData: TosData | null;
-};
+const Wrapper = styled.div`
+  position: absolute;
+  color: transparent;
+`;
 
-export const NotificationsAlert = ({ tosData }: Props) => {
+export const NotificationsAlert = () => {
   const signedIn = useAuthStore((store) => store.signedIn);
   const components = useBosComponents();
   const [showNotificationModalState, setShowNotificationModalState] = useState(false);
@@ -27,6 +29,7 @@ export const NotificationsAlert = ({ tosData }: Props) => {
   const [iosHomeScreenPrompt, setIosHomeScreenPrompt] = useState(false);
   const { isIosDevice, versionOfIos } = useIosDevice();
   const { showOnTS, subscribeStarted, subscribeError } = getNotificationLocalStorage() || {};
+  const tosData = useTermsOfServiceStore((store) => store.tosData);
 
   const handleModalCloseOnEsc = useCallback(() => {
     setShowNotificationModalState(false);
@@ -65,7 +68,7 @@ export const NotificationsAlert = ({ tosData }: Props) => {
       if (!subscribeError && showNotificationPrompt && tosAccepted && (!showOnTS || !iosHomeScreenPrompt)) {
         setTimeout(() => {
           setShowNotificationModalState(showNotificationPrompt);
-        }, 3000);
+        }, 4000);
       }
     }
   }, [tosData, subscribeError, showOnTS, iosHomeScreenPrompt]);
@@ -96,31 +99,35 @@ export const NotificationsAlert = ({ tosData }: Props) => {
   if (!signedIn) return null;
 
   return (
-    <>
-      <VmComponent
-        src={components.nearOrg.notifications.alert}
-        props={{
-          open: showNotificationModalState,
-          handleTurnOn: turnNotificationsOn,
-          handleOnCancel: pauseNotifications,
-          isNotificationSupported,
-          isPermisionGranted,
-          isPushManagerSupported,
-          setNotificationsSessionStorage,
-          onOpenChange: handleModalCloseOnEsc,
-          iOSDevice: isIosDevice,
-          iOSVersion: versionOfIos,
-          recomendedIOSVersion: recommendedIosVersionForNotifications,
-          loading: subscribeStarted,
-        }}
-      />
-      <VmComponent
-        src={components.nearOrg.notifications.iosHomeScreenAlert}
-        props={{
-          open: iosHomeScreenPrompt,
-          onOpenChange: handleHomeScreenClose,
-        }}
-      />
-    </>
+    <Wrapper>
+      {showNotificationModalState && (
+        <VmComponent
+          src={components.nearOrg.notifications.alert}
+          props={{
+            open: true,
+            handleTurnOn: turnNotificationsOn,
+            handleOnCancel: pauseNotifications,
+            isNotificationSupported,
+            isPermisionGranted,
+            isPushManagerSupported,
+            setNotificationsSessionStorage,
+            onOpenChange: handleModalCloseOnEsc,
+            iOSDevice: isIosDevice,
+            iOSVersion: versionOfIos,
+            recomendedIOSVersion: recommendedIosVersionForNotifications,
+            loading: subscribeStarted,
+          }}
+        />
+      )}
+      {iosHomeScreenPrompt && (
+        <VmComponent
+          src={components.nearOrg.notifications.iosHomeScreenAlert}
+          props={{
+            open: true,
+            onOpenChange: handleHomeScreenClose,
+          }}
+        />
+      )}
+    </Wrapper>
   );
 };

--- a/src/components/near-org/ComponentWrapperPage.tsx
+++ b/src/components/near-org/ComponentWrapperPage.tsx
@@ -18,7 +18,20 @@ export function ComponentWrapperPage(props: Props) {
   const setCurrentComponentSrc = useCurrentComponentStore((store) => store.setSrc);
 
   useEffect(() => {
-    setCurrentComponentSrc(props.src);
+    if (
+      props.componentProps &&
+      'targetComponent' in props.componentProps &&
+      typeof props.componentProps.targetComponent === 'string'
+    ) {
+      /*
+        If we're rendering a wrapper component, we want to display the component being wrapped
+        (props.componentProps.targetComponent). Without this check, we'd be rendering "GatewayWrapper"
+        or "TosCheck" as the current component instead of something like "ActivityPage".
+      */
+      setCurrentComponentSrc(props.componentProps.targetComponent);
+    } else {
+      setCurrentComponentSrc(props.src);
+    }
   }, [setCurrentComponentSrc, props]);
 
   return (

--- a/src/components/sandbox/Preview/index.js
+++ b/src/components/sandbox/Preview/index.js
@@ -4,7 +4,7 @@ import { VmComponent } from '@/components/vm/VmComponent';
 
 import { Layout, Tab } from '../utils/const';
 
-const Preview = ({ tab, layout, renderCode, jpath, parsedWidgetProps, isModule, widgets }) => (
+const Preview = ({ tab, layout, renderCode, jpath, parsedWidgetProps, isModule }) => (
   <div
     className={`${tab === Tab.Widget || (layout === Layout.Split && tab !== Tab.Metadata) ? '' : 'visually-hidden'}`}
   >
@@ -39,13 +39,7 @@ const Preview = ({ tab, layout, renderCode, jpath, parsedWidgetProps, isModule, 
                   margin: 0,
                 }}
               >
-                <VmComponent
-                  key={widgets.wrapper}
-                  src={widgets.wrapper}
-                  props={{
-                    children: <VmComponent key={`preview-${jpath}`} code={renderCode} props={parsedWidgetProps} />,
-                  }}
-                />
+                <VmComponent key={`preview-${jpath}`} code={renderCode} props={parsedWidgetProps} />
               </div>
             ) : (
               !isModule && (

--- a/src/components/sandbox/Sandbox.js
+++ b/src/components/sandbox/Sandbox.js
@@ -69,10 +69,6 @@ export const Sandbox = ({ onboarding = false }) => {
 
   const router = useRouter();
   const widgets = useBosComponents();
-  const tos = {
-    checkComponentPath: widgets.tosCheck,
-    contentComponentPath: widgets.tosContent,
-  };
 
   const [mainLoader, setMainLoader] = useState(false);
   const [filesObject, setFilesObject] = useState({});
@@ -538,7 +534,6 @@ export const Sandbox = ({ onboarding = false }) => {
               <div className="container-fluid mt-1" style={{ position: 'relative' }}>
                 <Search
                   widgets={widgets}
-                  tos={tos}
                   logOut={logOut}
                   loadAndOpenFile={loadAndOpenFile}
                   refs={refs}

--- a/src/components/sandbox/Search/index.js
+++ b/src/components/sandbox/Search/index.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import { VmComponent } from '@/components/vm/VmComponent';
+
 import { Filetype } from '../utils/const';
 
-const Search = ({ widgets, tos, logOut, loadAndOpenFile, refs, refSearch, disable }) => {
+const Search = ({ widgets, logOut, loadAndOpenFile, refs, refSearch, disable }) => {
   return (
     <>
       {widgets.editorComponentSearch && (
@@ -22,10 +23,9 @@ const Search = ({ widgets, tos, logOut, loadAndOpenFile, refs, refSearch, disabl
                     {/* We use the component search widget as a VM entry point to add a TOS check wrapper.
                 It does not need to be this component, just some <Widget /> on the page */}
                     <VmComponent
-                      src={tos.checkComponentPath}
+                      src={widgets.wrapper}
                       props={{
                         logOut: logOut,
-                        tosName: tos.contentComponentPath,
                         targetComponent: widgets.editorComponentSearch,
                         targetProps: () => ({
                           extraButtons: ({ widgetName, widgetPath, onHide }) => (

--- a/src/data/bos-components.ts
+++ b/src/data/bos-components.ts
@@ -40,8 +40,6 @@ type NetworkComponents = {
     indexPage: string;
     typeAheadDropdown: string;
   };
-  tosCheck: string;
-  tosContent: string;
   viewSource: string;
   widgetMetadata: string;
   widgetMetadataEditor: string;
@@ -95,12 +93,10 @@ export const componentsByNetworkId = ((): Record<NetworkId, NetworkComponents | 
         indexPage: `${testnetTLA}/widget/Search.IndexPage`,
         typeAheadDropdown: `${testnetTLA}/widget/Search.TypeAheadDropdown`,
       },
-      tosCheck: `${testnetTLA}/widget/TosCheck`,
-      tosContent: `${testnetTLA}/widget/TosContent`,
       viewSource: 'eugenethedream/widget/WidgetSource',
       widgetMetadata: 'eugenethedream/widget/WidgetMetadata',
       widgetMetadataEditor: `${testnetTLA}/widget/WidgetMetadataEditor`,
-      wrapper: `${testnetTLA}/widget/DIG.Theme`,
+      wrapper: `${testnetTLA}/widget/GatewayWrapper`,
     },
 
     mainnet: {
@@ -143,12 +139,10 @@ export const componentsByNetworkId = ((): Record<NetworkId, NetworkComponents | 
         indexPage: 'near/widget/Search.IndexPage',
         typeAheadDropdown: 'near/widget/Search.TypeAheadDropdown',
       },
-      tosCheck: 'near/widget/TosCheck',
-      tosContent: 'adminalpha.near/widget/TosContent',
       viewSource: 'mob.near/widget/WidgetSource',
       widgetMetadata: 'mob.near/widget/WidgetMetadata',
       widgetMetadataEditor: 'near/widget/WidgetMetadataEditor',
-      wrapper: 'near/widget/DIG.Theme',
+      wrapper: 'near/widget/GatewayWrapper',
     },
   };
 })();

--- a/src/pages/[componentAccountId]/widget/[componentName].tsx
+++ b/src/pages/[componentAccountId]/widget/[componentName].tsx
@@ -109,13 +109,12 @@ const ViewComponentPage: NextPageWithLayout = ({ meta }: InferGetServerSideProps
             }}
           >
             <VmComponent
-              key={components.tosCheck}
-              src={components.tosCheck}
+              key={components.wrapper}
+              src={components.wrapper}
               props={{
                 logOut: authStore.logOut,
                 targetProps: componentProps,
                 targetComponent: componentSrc,
-                tosName: components.tosContent,
               }}
             />
           </div>

--- a/src/pages/embed/[accountId]/widget/[componentName].tsx
+++ b/src/pages/embed/[accountId]/widget/[componentName].tsx
@@ -27,11 +27,10 @@ const EmbedComponentPage: NextPageWithLayout = () => {
   return (
     <div className="d-inline-block position-relative overflow-hidden">
       <VmComponent
-        key={components.tosCheck}
-        src={components.tosCheck}
+        key={components.wrapper}
+        src={components.wrapper}
         props={{
           logOut: authStore.logOut,
-          tosName: components.tosContent,
           targetComponent: componentSrc,
           targetProps: componentProps,
         }}

--- a/src/stores/terms-of-service.ts
+++ b/src/stores/terms-of-service.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+import type { TosData } from '@/utils/types';
+
+type TermsOfServiceStore = {
+  tosData: TosData | null;
+  setTosData: (tosData: TosData | null) => void;
+};
+
+export const useTermsOfServiceStore = create<TermsOfServiceStore>((set, get) => ({
+  tosData: null,
+  setTosData: (tosData) => {
+    const state = get();
+
+    if (!tosData || state.tosData?.latestTosVersion === tosData.latestTosVersion) {
+      return;
+    }
+
+    set(() => ({ tosData }));
+  },
+}));


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery/issues/673

- We are now using `GatewayWrapper` instead of using `TosCheck` directly to make our entry points more consistent. This allows us to easily extend `GatewayWrapper` as we need to introduce more global functionality. The biggest benefit though is that once `TosCheck` loads the data it needs, it won't cause a full re-render of the corresponding page.
- Updated `NotificationAlert` to rely on a Zustand store so that we can pass it `tosData` without causing a full re-render of the `ActivityPage` (pages/index.tsx).
- Removed the unnecessary wrapper that was used to wrap the sandbox preview. This used to be required due to us relying on `DIG.Theme` (those theme variables are provided by the gateway's `theme.css` file now).

NOTE: The best way to test these changes will be running the components repo on the `develop` branch using `bos-loader`.