### PR TITLE
Upgrading to VM 2.5.2 to support styled("Link")

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "local-storage": "^2.0.0",
         "lodash": "^4.17.21",
         "near-fastauth-wallet": "^0.0.9",
-        "near-social-vm": "github:NearSocial/VM#2.5.1",
+        "near-social-vm": "github:NearSocial/VM#2.5.2",
         "next": "13.3.4",
         "prettier": "^2.7.1",
         "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@braintree/sanitize-url':
     specifier: 6.0.0
@@ -120,8 +116,8 @@ dependencies:
     specifier: ^0.0.9
     version: 0.0.9
   near-social-vm:
-    specifier: github:NearSocial/VM#2.5.1
-    version: github.com/NearSocial/VM/32a404f19063eb53e907980bbfc56601fb608e8a(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    specifier: github:NearSocial/VM#2.5.2
+    version: github.com/NearSocial/VM/9fe2d4ec05727ee2e2db8ddf198556220a169a4f(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
   next:
     specifier: 13.3.4
     version: 13.3.4(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
@@ -10579,11 +10575,11 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
 
-  github.com/NearSocial/VM/32a404f19063eb53e907980bbfc56601fb608e8a(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
-    resolution: {tarball: https://codeload.github.com/NearSocial/VM/tar.gz/32a404f19063eb53e907980bbfc56601fb608e8a}
-    id: github.com/NearSocial/VM/32a404f19063eb53e907980bbfc56601fb608e8a
+  github.com/NearSocial/VM/9fe2d4ec05727ee2e2db8ddf198556220a169a4f(@babel/core@7.23.0)(@popperjs/core@2.11.8)(@types/react-dom@18.2.1)(@types/react@18.2.0)(near-api-js@2.1.4)(prop-types@15.8.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
+    resolution: {tarball: https://codeload.github.com/NearSocial/VM/tar.gz/9fe2d4ec05727ee2e2db8ddf198556220a169a4f}
+    id: github.com/NearSocial/VM/9fe2d4ec05727ee2e2db8ddf198556220a169a4f
     name: near-social-vm
-    version: 2.5.1
+    version: 2.5.2
     peerDependencies:
       near-api-js: 2.1.3
       react: ^18.2.0
@@ -10661,3 +10657,7 @@ packages:
       - supports-color
       - utf-8-validate
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
Related to: https://github.com/near/near-discovery/issues/739

Once we merge this and confirm our dev environment looks good, we'll also want to quickly merge this hotfix: https://github.com/near/near-discovery/pull/768