### PR TITLE
Fix Edit Redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,11 +45,6 @@ const nextConfig = {
         destination: 'https://pages.near.org/validators',
         permanent: true,
       },
-      {
-        source: '/edit/:path*',
-        destination: '/sandbox/:path*',
-        permanent: true,
-      },
     ];
   },
   rewrites: async () => [
@@ -62,10 +57,9 @@ const nextConfig = {
 
 module.exports = nextConfig;
 
-
 // Injected content via Sentry wizard below
 
-const { withSentryConfig } = require("@sentry/nextjs");
+const { withSentryConfig } = require('@sentry/nextjs');
 
 module.exports = withSentryConfig(
   module.exports,
@@ -76,8 +70,8 @@ module.exports = withSentryConfig(
     // Suppresses source map uploading logs during build
     silent: true,
 
-    org: "near-protocol",
-    project: "near-discovery",
+    org: 'near-protocol',
+    project: 'near-discovery',
   },
   {
     // For all available options, see:
@@ -90,12 +84,12 @@ module.exports = withSentryConfig(
     transpileClientSDK: true,
 
     // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
-    tunnelRoute: "/monitoring",
+    tunnelRoute: '/monitoring',
 
     // Hides source maps from generated client bundles
     hideSourceMaps: true,
 
     // Automatically tree-shake Sentry logger statements to reduce bundle size
     disableLogger: true,
-  }
+  },
 );

--- a/src/hooks/useHashUrlBackwardsCompatibility.ts
+++ b/src/hooks/useHashUrlBackwardsCompatibility.ts
@@ -6,9 +6,7 @@ export function useHashUrlBackwardsCompatibility() {
 
   const onHashChange = useCallback(
     (event: HashChangeEvent) => {
-      let url = event.newURL.split('#').pop() ?? '/';
-      url = url.replace(/^\/edit/, '/sandbox');
-
+      const url = event.newURL.split('#').pop() ?? '/';
       if (url[0] === '/') {
         router.replace(url);
       }

--- a/src/pages/edit/[...componentSrc].tsx
+++ b/src/pages/edit/[...componentSrc].tsx
@@ -1,0 +1,2 @@
+import EditPage from './index';
+export default EditPage;

--- a/src/pages/edit/index.tsx
+++ b/src/pages/edit/index.tsx
@@ -1,0 +1,19 @@
+import { Sandbox } from '@/components/sandbox';
+import { useDefaultLayout } from '@/hooks/useLayout';
+import type { NextPageWithLayout } from '@/utils/types';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const EditPage: NextPageWithLayout = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace(router.asPath.replace('/edit/', '/sandbox/'));
+  }, []);
+
+  return null;
+};
+
+EditPage.getLayout = useDefaultLayout;
+
+export default EditPage;

--- a/src/pages/edit/index.tsx
+++ b/src/pages/edit/index.tsx
@@ -8,7 +8,7 @@ const EditPage: NextPageWithLayout = () => {
   const router = useRouter();
 
   useEffect(() => {
-    router.replace(router.asPath.replace('/edit/', '/sandbox/'));
+    router.replace(router.asPath.replace(/^\/edit/, '/sandbox'));
   }, []);
 
   return null;


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery-components/issues/458

Turns out that redirects configured in `next.config.js` don't apply to client side routing (they only run when visiting a URL directly - with a full page reload):

> Redirects are not applied to client-side routing (Link, router.push)...

https://nextjs.org/docs/pages/api-reference/next-config-js/redirects

So I set up an explicit page route to handle all redirect edge cases in a single location when redirecting from `/edit/...` to `/sandbox/...`