### PR TITLE
Add /relayer-demo route

### DIFF
--- a/src/data/bos-components.ts
+++ b/src/data/bos-components.ts
@@ -30,6 +30,7 @@ type NetworkComponents = {
     };
     learnPage: string;
   };
+  relayerDemo: string;
   notificationButton: string;
   peoplePage: string;
   profileImage: string;
@@ -83,6 +84,7 @@ export const componentsByNetworkId = ((): Record<NetworkId, NetworkComponents | 
         },
         learnPage: `${testnetTLA}/widget/NearOrg.LearnPage`,
       },
+      relayerDemo: 'one.testnet/widget/RelayerMessageDemo',
       notificationButton: `${testnetTLA}/widget/NotificationButton`,
       peoplePage: `${testnetTLA}/widget/PeoplePage`,
       profileImage: 'eugenethedream/widget/ProfileImage',
@@ -129,6 +131,7 @@ export const componentsByNetworkId = ((): Record<NetworkId, NetworkComponents | 
         },
         learnPage: 'near/widget/NearOrg.LearnPage',
       },
+      relayerDemo: 'relayer-demo.near/widget/RelayerMessageDemo',
       notificationButton: 'near/widget/NotificationButton',
       peoplePage: 'near/widget/PeoplePage',
       profileImage: 'mob.near/widget/ProfileImage',

--- a/src/pages/relayer-demo.tsx
+++ b/src/pages/relayer-demo.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
+import { useBosComponents } from '@/hooks/useBosComponents';
+import { useDefaultLayout } from '@/hooks/useLayout';
+import { useAuthStore } from '@/stores/auth';
+import type { NextPageWithLayout } from '@/utils/types';
+import { networkId } from '@/utils/config';
+
+const RelayerDemoPage: NextPageWithLayout = () => {
+  const components = useBosComponents();
+  const vmNear = useAuthStore((store) => store.vmNear);
+
+  useEffect(() => {
+    vmNear?.selector
+      .then((selector: any) => selector.wallet('fast-auth-wallet'))
+      .then((fastAuthWallet: any) =>
+        fastAuthWallet.setRelayerUrl({
+          relayerUrl:
+            networkId === 'testnet'
+              ? 'http://fastauth.demo.near-relayer-testnet.api.pagoda.co/relay'
+              : 'http://basic.demo.near-relayer-mainnet.api.pagoda.co/relay',
+        }),
+      );
+  }, [vmNear?.selector]);
+
+  useEffect(() => {
+    return () => {
+      vmNear?.selector
+        .then((selector: any) => selector.wallet('fast-auth-wallet'))
+        .then((fastAuthWallet: any) => fastAuthWallet.resetRelayerUrl());
+    };
+  }, []);
+
+  return <ComponentWrapperPage src={components.relayerDemo} meta={{ title: 'NEAR | Relayer Demo', description: '' }} />;
+};
+
+RelayerDemoPage.getLayout = useDefaultLayout;
+
+export default RelayerDemoPage;


### PR DESCRIPTION
Adding a `/relayer-demo` route that manually sets the relayer URL on mount, and resets the relayer URL on unmount.

The route renders a [BOS component](https://near.org/relayer-demo.near/widget/RelayerMessageDemo) which allows users with FastAuth account + zero balance to add messages to the `guest-book.near` contract.
