### PR TITLE
Reveal data availability link in header

### DIFF
--- a/src/components/navigation/navigation-categories.ts
+++ b/src/components/navigation/navigation-categories.ts
@@ -22,13 +22,10 @@ export const navigationCategories = [
             title: 'Data Infrastructure',
             url: '/data-infrastructure',
           },
-
-          // The following link should be uncommented and deployed on Nov 9th:
-
-          // {
-          //   title: 'Data Availability',
-          //   url: '/data-availability',
-          // },
+          {
+            title: 'Data Availability',
+            url: '/data-availability',
+          },
         ],
       },
     ],


### PR DESCRIPTION
We can safely merge this into `develop` now. We'll open another PR to sync `main` tomorrow (on the 8th).