### PR TITLE
refactor: Change idOS data storage

### DIFF
--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -1,5 +1,6 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import { setupKeypom } from '@keypom/selector';
+import type { WalletSelector } from '@near-wallet-selector/core';
 import { setupWalletSelector } from '@near-wallet-selector/core';
 import { setupHereWallet } from '@near-wallet-selector/here-wallet';
 import { setupLedger } from '@near-wallet-selector/ledger';
@@ -31,6 +32,7 @@ import { useEthersProviderContext } from '@/data/web3';
 import { useIdOS } from '@/hooks/useIdOS';
 import { useSignInRedirect } from '@/hooks/useSignInRedirect';
 import { useAuthStore } from '@/stores/auth';
+import { useIdosStore } from '@/stores/idosStore';
 import { useVmStore } from '@/stores/vm';
 import { recordWalletConnect, reset as resetAnalytics } from '@/utils/analytics';
 import { networkId, signInContractId } from '@/utils/config';
@@ -108,7 +110,7 @@ export default function VmInitializer() {
     if (!near || !idOS) {
       return;
     }
-    near.selector.then((selector: any) => {
+    near.selector.then((selector: WalletSelector) => {
       const selectorModal = setupModal(selector, {
         contractId: near.config.contractName,
         methodNames: idOS.near.contractMethods,
@@ -162,6 +164,7 @@ export default function VmInitializer() {
     if (!near) {
       return;
     }
+    useIdosStore.persist.clearStorage();
     const wallet = await (await near.selector).wallet();
     wallet.signOut();
     near.accountId = null;

--- a/src/hooks/useIdOS.ts
+++ b/src/hooks/useIdOS.ts
@@ -5,25 +5,24 @@ import { useIdosStore } from '@/stores/idosStore';
 
 export function useIdOS() {
   const setIdosStore = useIdosStore((state) => state.set);
+  const idosStore = useIdosStore((state) => state.idOS);
 
   const init = useCallback(async () => {
-    await new Promise<void>(async (resolve, reject) => {
-      try {
-        const idos = (await idOS.init({ container: '#idos_container' } as {
-          nodeUrl: string;
-          container: string;
-        })) as any;
-        setIdosStore({ idOS: idos });
-        resolve();
-      } catch (error: any) {
-        console.error('Failed to initialize IDOS: ', error);
-        reject();
-      }
-    });
+    try {
+      const idos = (await idOS.init({ container: '#idos_container' } as {
+        nodeUrl: string;
+        container: string;
+      })) as any;
+      setIdosStore({ idOS: idos });
+    } catch (error: any) {
+      console.error('Failed to initialize IDOS: ', error);
+    }
   }, [setIdosStore]);
 
   useEffect(() => {
-    init();
-  }, [init, setIdosStore]);
+    if (!idosStore) {
+      init();
+    }
+  }, [idosStore, init, setIdosStore]);
   return idOS;
 }

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import type { WalletSelector } from '@near-wallet-selector/core';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
 
 import { openToast } from '@/components/lib/Toast';
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
@@ -6,7 +8,7 @@ import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useIdosStore } from '@/stores/idosStore';
-import type { NextPageWithLayout } from '@/utils/types';
+import type { IdosUser, NextPageWithLayout } from '@/utils/types';
 
 const SettingsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
@@ -15,54 +17,53 @@ const SettingsPage: NextPageWithLayout = () => {
   const idosUser = useIdosStore((state) => state.currentUser);
   const idosCredentials = useIdosStore((state) => state.credentials);
   const setIdosStore = useIdosStore((state) => state.set);
+  const [error, setError] = useState<string | null>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
   const createAccountUrl =
     'https://app.fractal.id/authorize?client_id=PXAbBxPErSPMXiKmMYQ3ged8Qxwqg1Px7ymhsuhaGP4&redirect_uri=https%3A%2F%2Fnear.org%2Fsettings&response_type=code&scope=contact%3Aread%20verification.uniqueness%3Aread%20verification.uniqueness.details%3Aread%20verification.idos%3Aread%20verification.idos.details%3Aread%20verification.wallet-near%3Aread%20verification.wallet-near.details%3Aread';
+  const router = useRouter();
 
   const connectIdOS = useCallback(async () => {
-    if (!near || !idOS) {
-      return;
-    }
-    const wallet = await (await near.selector).wallet();
-    await new Promise<void>(async (resolve, reject) => {
-      try {
-        const currentUser = (await idOS.setSigner('NEAR', wallet)) as any;
-        setIdosStore({ currentUser });
-        resolve();
-      } catch (error: any) {
-        console.error('Failed to init wallet + idOS: ', error);
-        const errorMessage = error.message ? error.message : 'unknown';
+    if (!near || !idOS) return;
+    const wallet = (await (await near.selector).wallet()) as WalletSelector['wallet'];
+    try {
+      const currentUser = idosUser ?? ((await idOS.setSigner('NEAR', wallet)) as unknown as IdosUser);
+      setIdosStore({ currentUser });
+    } catch (error: any) {
+      console.error('Failed to init wallet + idOS: ', error);
+      const errorMessage = error.message ? error.message : 'unknown';
+      setError(errorMessage);
+    } finally {
+      if ((idosUser && !idosUser.humanId) || (!idosCredentials && error)) {
         openToast({
           type: 'ERROR',
           title: 'Failed to init wallet + idOS:',
-          description: `${errorMessage}`,
+          description: `${error}`,
         });
-        reject();
       }
-    });
-  }, [idOS, near, setIdosStore]);
+    }
+  }, [error, idOS, idosCredentials, idosUser, near, setIdosStore]);
 
   const collectUserInfo = useCallback(async () => {
     if (!idOS) {
       return;
     }
 
-    await new Promise<void>(async (resolve, reject) => {
-      try {
-        const credentials = await idOS.data.list('credentials');
+    try {
+      if (!idosCredentials) {
+        const credentials = idosCredentials ?? (await idOS.data.list('credentials'));
         setIdosStore({ credentials });
-        resolve();
-      } catch (error: any) {
-        const errorMessage = error.message ? error.message : 'unknown';
-        console.error('Failed to get credentials: ', error);
-        openToast({
-          type: 'ERROR',
-          title: 'Failed to get credentials from IDOS',
-          description: `${errorMessage}`,
-        });
-        reject();
       }
-    });
-  }, [idOS, setIdosStore]);
+    } catch (error: any) {
+      const errorMessage = error.message ? error.message : 'unknown';
+      console.error('Failed to get credentials: ', error);
+      openToast({
+        type: 'ERROR',
+        title: 'Failed to get credentials from IDOS',
+        description: `${errorMessage}`,
+      });
+    }
+  }, [idOS, idosCredentials, setIdosStore]);
 
   useEffect(() => {
     if (idosUser && !idosUser.humanId) {
@@ -73,16 +74,22 @@ const SettingsPage: NextPageWithLayout = () => {
       });
 
       setTimeout(() => {
-        window.location.href = createAccountUrl;
+        router.push(createAccountUrl);
       }, 3000);
     }
-  }, [idosUser, idOS]);
+  }, [idosUser, idOS, router]);
 
   useEffect(() => {
     if (idosUser && idosUser.humanId && !idosCredentials) {
       collectUserInfo();
     }
   }, [collectUserInfo, idosCredentials, idosUser]);
+
+  useEffect(() => {
+    if (router && router.query && router.query.code) {
+      setShowTooltip(true);
+    }
+  }, [router]);
 
   return (
     <ComponentWrapperPage
@@ -92,6 +99,7 @@ const SettingsPage: NextPageWithLayout = () => {
         idosConnected: idosUser?.humanId ?? false,
         connectIdOS,
         idosCredentials,
+        showTooltip: showTooltip ?? false,
       }}
     />
   );

--- a/src/stores/idosStore.ts
+++ b/src/stores/idosStore.ts
@@ -1,5 +1,6 @@
 import type { idOS } from '@idos-network/idos-sdk';
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type { IdosUser, IdosWalletInfo } from '@/utils/types';
 
@@ -16,10 +17,20 @@ type IdosStore = IdosState & {
   set: (state: IdosState) => void;
 };
 
-export const useIdosStore = create<IdosStore>((set) => ({
-  idOS: undefined,
-  currentUser: undefined,
-  credentials: undefined,
-  wallets: undefined,
-  set: (state) => set((previousState) => ({ ...previousState, ...state })),
-}));
+export const useIdosStore = create(
+  persist(
+    (set) => ({
+      idOS: undefined,
+      currentUser: undefined,
+      credentials: undefined,
+      wallets: undefined,
+      set: (state) => set((previousState) => ({ ...previousState, ...state })),
+    }),
+    {
+      name: 'idOS-user-info',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state: IdosStore) =>
+        Object.fromEntries(Object.entries(state).filter(([key]) => !['idOS'].includes(key))),
+    },
+  ),
+);


### PR DESCRIPTION
This PR introduces changes for idOS store. From now we're storing the data in localStorage but using zustand which means we have more control on it + clear this store on logout. 

Also this PR introduces smaller changes like refactor idOS methods to get the data and better error handling.

Closes: [#493](https://github.com/near/near-discovery-components/issues/493), [#494](https://github.com/near/near-discovery-components/issues/494)