### PR TITLE
Temporarily disable api.near.social calls due to outage

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
     <option name="myRunOnSave" value="true" />
   </component>
 </project>

--- a/src/pages/[componentAccountId]/widget/[componentName].tsx
+++ b/src/pages/[componentAccountId]/widget/[componentName].tsx
@@ -42,23 +42,24 @@ function returnImageUrl(data: ImageData | undefined) {
 }
 
 async function fetchPreviewData(accountId: string, componentName: string): Promise<ComponentMetaPreview | null> {
-  const response = await fetch(`https://api.near.social/get?keys=${accountId}/widget/${componentName}/**`);
-  const responseData: ComponentPayload = await response.json();
-  const metadata = responseData[accountId]?.widget?.[componentName]?.metadata;
-
-  if (!metadata) {
-    return null;
-  }
-
-  const strippedDescriptionVFile = await remark().use(strip).process(metadata.description);
-  // recommended conversion from remark docs
-  const strippedDescription = String(strippedDescriptionVFile);
-
-  return {
-    title: `${metadata.name} by ${accountId} on BOS`,
-    description: strippedDescription,
-    imageUrl: returnImageUrl(metadata.image),
-  };
+  return null;
+  // const response = await fetch(`https://api.near.social/get?keys=${accountId}/widget/${componentName}/**`);
+  // const responseData: ComponentPayload = await response.json();
+  // const metadata = responseData[accountId]?.widget?.[componentName]?.metadata;
+  //
+  // if (!metadata) {
+  //   return null;
+  // }
+  //
+  // const strippedDescriptionVFile = await remark().use(strip).process(metadata.description);
+  // // recommended conversion from remark docs
+  // const strippedDescription = String(strippedDescriptionVFile);
+  //
+  // return {
+  //   title: `${metadata.name} by ${accountId} on BOS`,
+  //   description: strippedDescription,
+  //   imageUrl: returnImageUrl(metadata.image),
+  // };
 }
 
 export const getServerSideProps: GetServerSideProps<{

--- a/src/pages/s/[urlShareIndicator].tsx
+++ b/src/pages/s/[urlShareIndicator].tsx
@@ -66,39 +66,39 @@ function returnShareType(indicator: string): ShareType {
 }
 
 async function returnMetaPreviewForComment(accountId: string, blockHeight: string): Promise<MetaPreview | null> {
-  const response = await fetch(`https://api.near.social/get?keys=${accountId}/post/comment&blockHeight=${blockHeight}`);
-  const responseData: CommentPostData = await response.json();
-  const comment = responseData[accountId]?.post.comment;
-
-  if (comment) {
-    const data: StringifiedData = JSON.parse(comment);
-
-    return {
-      title: `Comment by @${accountId}`,
-      description: sanitizeText(data.text),
-      imageUrl: returnImageUrl(data.image),
-      redirectUrl: `/near/widget/PostPage?accountId=${accountId}&commentBlockHeight=${blockHeight}`,
-    };
-  }
+  // const response = await fetch(`https://api.near.social/get?keys=${accountId}/post/comment&blockHeight=${blockHeight}`);
+  // const responseData: CommentPostData = await response.json();
+  // const comment = responseData[accountId]?.post.comment;
+  //
+  // if (comment) {
+  //   const data: StringifiedData = JSON.parse(comment);
+  //
+  //   return {
+  //     title: `Comment by @${accountId}`,
+  //     description: sanitizeText(data.text),
+  //     imageUrl: returnImageUrl(data.image),
+  //     redirectUrl: `/near/widget/PostPage?accountId=${accountId}&commentBlockHeight=${blockHeight}`,
+  //   };
+  // }
 
   return null;
 }
 
 async function returnMetaPreviewForPost(accountId: string, blockHeight: string): Promise<MetaPreview | null> {
-  const response = await fetch(`https://api.near.social/get?keys=${accountId}/post/main&blockHeight=${blockHeight}`);
-  const responseData: MainPostData = await response.json();
-  const main = responseData[accountId]?.post.main;
-
-  if (main) {
-    const data: StringifiedData = JSON.parse(main);
-
-    return {
-      title: `Post by @${accountId}`,
-      description: sanitizeText(data.text),
-      imageUrl: returnImageUrl(data.image),
-      redirectUrl: `/near/widget/PostPage?accountId=${accountId}&blockHeight=${blockHeight}`,
-    };
-  }
+  // const response = await fetch(`https://api.near.social/get?keys=${accountId}/post/main&blockHeight=${blockHeight}`);
+  // const responseData: MainPostData = await response.json();
+  // const main = responseData[accountId]?.post.main;
+  //
+  // if (main) {
+  //   const data: StringifiedData = JSON.parse(main);
+  //
+  //   return {
+  //     title: `Post by @${accountId}`,
+  //     description: sanitizeText(data.text),
+  //     imageUrl: returnImageUrl(data.image),
+  //     redirectUrl: `/near/widget/PostPage?accountId=${accountId}&blockHeight=${blockHeight}`,
+  //   };
+  // }
 
   return null;
 }


### PR DESCRIPTION
From outage thread: https://pagodaplatform.slack.com/archives/C025P00N3QD/p1701264395404659