### PR TITLE
fix: Fixed zendesk icon over modal

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -109,6 +109,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
           window.zESettings = {
             webWidget: {
               color: { theme: '#2b2f31' },
+              zIndex: 1022,
               offset: {
                 horizontal: '10px',
                 vertical: '10px',


### PR DESCRIPTION
Fixed issue with zendesk icon on mobile phones. Issue on [link](https://github.com/near/near-discovery-components/issues/392).

Also I had found that when you try to sign in, icon is going over sign in. In this case, that is handled too. 