### PR TITLE
fix: custom Link element should handle when href is undefined

### DIFF
--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -106,6 +106,7 @@ export default function VmInitializer() {
           Link: ({ to, href, ...rest }: { to: string | object | undefined; href: string | object }) => {
             const cleanProps = mapValues({ to, href, ...rest }, (val: any, key: string) => {
               if (!['to', 'href'].includes(key)) return val;
+              if (key === 'href' && !val) val = to;
               return typeof val === 'string' && isValidAttribute('a', 'href', val) ? val : 'about:blank';
             });
 


### PR DESCRIPTION
Some `<Link>` instances define their destination using`to` instead of `href`. This PR handles that case and fixes broken links like communities and activity feed on [DevHub](https://near.org/devhub.near/widget/app)