### PR TITLE
feat: trigger events if redirect search params are present

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,11 +1,9 @@
-import { getKeys, isPassKeyAvailable } from '@near-js/biometric-ed25519';
-import { useRouter } from 'next/router';
+import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
 
 import { Button } from '@/components/lib/Button';
-import { openToast } from '@/components/lib/Toast';
 import { useClearCurrentComponent } from '@/hooks/useClearCurrentComponent';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useSignInRedirect } from '@/hooks/useSignInRedirect';
@@ -17,10 +15,10 @@ import { isValidEmail } from '../utils/form-validation';
 
 const SignInPage: NextPageWithLayout = () => {
   const { register, handleSubmit, setValue } = useForm();
-  const router = useRouter();
   const requestSignInWithWallet = useAuthStore((store) => store.requestSignInWithWallet);
   const signedIn = useAuthStore((store) => store.signedIn);
   const vmNear = useAuthStore((store) => store.vmNear);
+  const searchParams = useSearchParams();
   const { redirect } = useSignInRedirect();
 
   useEffect(() => {
@@ -28,6 +26,18 @@ const SignInPage: NextPageWithLayout = () => {
       redirect();
     }
   }, [redirect, signedIn]);
+
+  useEffect(() => {
+    if (vmNear?.selector && searchParams.get('account_id') && searchParams.get('public_key')) {
+      vmNear.selector
+        .then((selector: any) => selector.wallet('fast-auth-wallet'))
+        .then((fastAuthWallet: any) =>
+          fastAuthWallet.signIn({
+            contractId: vmNear.config.contractName,
+          }),
+        );
+    }
+  }, [searchParams, vmNear]);
 
   useClearCurrentComponent();
 


### PR DESCRIPTION
Patches a low level issue with the wallet selector observable not firing in some cases with the new account information after we redirect back to discovery with the query params to complete sign in. [The VM subscribes to this observable to determine logged in state](https://github.com/NearSocial/VM/blob/master/src/lib/data/account.js#L111) so in these cases the user remains logged out even after completing the sign in flow