### PR TITLE
fix(headers): temporarily remove to fix issues resolving ipfs images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,15 +58,7 @@ const nextConfig = {
       source: '/api/analytics/:path*',
       destination: 'https://near.dataplane.rudderstack.com/:path*',
     }
-  ],
-  headers: async () => [
-    {
-      source: '/:path*',
-      headers: [{
-        key: 'Referrer-Policy',
-        value: 'strict-origin-when-cross-origin,same-origin'
-      }]
-  }]
+  ]
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Will need to look into a work around to support sending same origin referrer headers without breaking [social ipfs images](https://near.org/near/widget/ComponentDetailsPage?src=mob.near/widget/Image)