### PR TITLE
Specifies a referrer policy to ensure we pass the referrer to analytics

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,6 +58,15 @@ const nextConfig = {
       source: '/api/analytics/:path*',
       destination: 'https://near.dataplane.rudderstack.com/:path*',
     }
+  ],
+  headers: async () => [
+    {
+        source: '/:path*',
+        headers: [{
+          key: 'Referrer-Policy',
+          value: 'strict-origin-when-cross-origin'
+        }]
+      }
   ]
 };
 


### PR DESCRIPTION
The previous attempt coupled two referrer policies in one array value declaration, causing an error. We actually only need to specify this one value to ensure that the referring origin is passed to cross-domain requests and the entire path passed for same-origin.