### PR TITLE
fix: update github link to point to org readme

### DIFF
--- a/src/components/navigation/navigation-categories.ts
+++ b/src/components/navigation/navigation-categories.ts
@@ -81,7 +81,7 @@ export const navigationCategories = [
           },
           {
             title: 'GitHub',
-            url: 'https://github.com/near/dx',
+            url: 'https://github.com/near',
           },
           {
             title: 'Standards & Proposals',


### PR DESCRIPTION
Updates github link on near.org to point to GH org's README. DX content has been migrated there :) 