### PR TITLE
route to /papers/nightshade

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,6 +56,11 @@ const nextConfig = {
         source: '/da',
         destination: '/data-availability',
         permanent: true,
+      },
+      {
+        source: '/papers/nightshade',
+        destination: '/files/nightshade.pdf',
+        permanent: true,
       }
     ];
   },


### PR DESCRIPTION
 with the recent /papers rebuild we lost a direct route to /papers/nightshade