### PR TITLE
route existing sign in/up links to overlay the new auth modal on the applications page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -71,6 +71,17 @@ const nextConfig = {
         source: '/horizon',
         destination: '/founders',
         permanent: true,
+      },
+      {
+        source: '/signin',
+        destination: '/applications?requestAuth=1',
+        permanent: false,
+      }
+      ,
+      {
+        source: '/signup',
+        destination: '/applications?requestAuth=1&createAccount=1',
+        permanent: false,
       }
     ];
   },

--- a/src/pages/[componentAccountId]/widget/[componentName].tsx
+++ b/src/pages/[componentAccountId]/widget/[componentName].tsx
@@ -1,10 +1,10 @@
-import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { remark } from 'remark';
 import strip from 'strip-markdown';
 
-import { MetaTags } from '@/components/MetaTags';
+import { useSignInRedirect } from '@/hooks/useSignInRedirect';
 import { VmComponent } from '@/components/vm/VmComponent';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
@@ -108,6 +108,14 @@ const ViewComponentPage: NextPageWithLayout = () => {
   const authStore = useAuthStore();
   const components = useBosComponents();
   const cookieData = useCookiePreferences();
+  const { requestAuthentication } = useSignInRedirect();
+
+  useEffect(() => {
+    const { requestAuth, createAccount } = componentProps;
+    if (requestAuth) {
+      requestAuthentication(!!createAccount);
+    }
+  }, [componentProps, requestAuthentication]);
 
   useEffect(() => {
     setComponentSrc(componentSrc);

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -1,10 +1,22 @@
 import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useSignInRedirect } from '@/hooks/useSignInRedirect';
 import type { NextPageWithLayout } from '@/utils/types';
 
 const ApplicationsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
+  const router = useRouter();
+  const { requestAuthentication } = useSignInRedirect();
+
+  useEffect(() => {
+    const { requestAuth, createAccount } = router.query;
+    if (requestAuth) {
+      requestAuthentication(!!createAccount);
+    }
+  }, [requestAuthentication, router.query]);
 
   return (
     <ComponentWrapperPage


### PR DESCRIPTION
Building upon [this pr](https://github.com/near/near-discovery/pull/1017), this updates the remaining signin flows to use the new auth modal 

closes https://github.com/near/near-discovery/issues/970