### PR TITLE
fix: avoid triggering the sign-in modal if user has already authenticated

### DIFF
--- a/src/pages/[componentAccountId]/widget/[componentName].tsx
+++ b/src/pages/[componentAccountId]/widget/[componentName].tsx
@@ -112,10 +112,10 @@ const ViewComponentPage: NextPageWithLayout = () => {
 
   useEffect(() => {
     const { requestAuth, createAccount } = componentProps;
-    if (requestAuth) {
+    if (requestAuth && !authStore.account) {
       requestAuthentication(!!createAccount);
     }
-  }, [componentProps, requestAuthentication]);
+  }, [authStore, componentProps, requestAuthentication]);
 
   useEffect(() => {
     setComponentSrc(componentSrc);

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -3,6 +3,7 @@ import { useBosComponents } from '@/hooks/useBosComponents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useAuthStore } from '@/stores/auth';
 import { useSignInRedirect } from '@/hooks/useSignInRedirect';
 import type { NextPageWithLayout } from '@/utils/types';
 
@@ -10,13 +11,14 @@ const ApplicationsPage: NextPageWithLayout = () => {
   const components = useBosComponents();
   const router = useRouter();
   const { requestAuthentication } = useSignInRedirect();
+  const authStore = useAuthStore();
 
   useEffect(() => {
     const { requestAuth, createAccount } = router.query;
-    if (requestAuth) {
+    if (requestAuth && !authStore.account) {
       requestAuthentication(!!createAccount);
     }
-  }, [requestAuthentication, router.query]);
+  }, [authStore, requestAuthentication, router.query]);
 
   return (
     <ComponentWrapperPage


### PR DESCRIPTION
1. visit near.org preview link
2. connect wallet
3. visit preview-link/signin
4. visit preview-link/signup
5. You remain logged in and the auth modal should not reappear