### PR TITLE
Pinned Apps (2 of 2)

### DIFF
--- a/src/components/lib/Text/Text.tsx
+++ b/src/components/lib/Text/Text.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 type Props = {
   color?: string;
-  font?: string;
+  font?: 'text-xs' | 'text-s' | 'text-base' | 'text-l' | 'text-xl' | 'text-2xl' | 'text-3xl' | 'text-hero';
   weight?: string;
 };
 

--- a/src/components/near-org/ComponentWrapperPage.tsx
+++ b/src/components/near-org/ComponentWrapperPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { VmComponent } from '@/components/vm/VmComponent';
+import { useGatewayEvents } from '@/hooks/useGatewayEvents';
 import { useCurrentComponentStore } from '@/stores/current-component';
 
 import { MetaTags } from '../MetaTags';
@@ -16,6 +17,7 @@ type Props = {
 
 export function ComponentWrapperPage(props: Props) {
   const setCurrentComponentSrc = useCurrentComponentStore((store) => store.setSrc);
+  const { emitGatewayEvent } = useGatewayEvents();
 
   useEffect(() => {
     if (
@@ -37,7 +39,7 @@ export function ComponentWrapperPage(props: Props) {
   return (
     <>
       {props.meta && <MetaTags {...props.meta} />}
-      <VmComponent src={props.src} props={props.componentProps} />
+      <VmComponent src={props.src} props={{ ...props.componentProps, emitGatewayEvent }} />
     </>
   );
 }

--- a/src/components/sidebar-navigation/PinnedApps.tsx
+++ b/src/components/sidebar-navigation/PinnedApps.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable @next/next/no-img-element */
+
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import { useBosComponents } from '@/hooks/useBosComponents';
+import { useAuthStore } from '@/stores/auth';
+
+import { Button } from '../lib/Button';
+import { Text } from '../lib/Text';
+import { Tooltip } from '../lib/Tooltip';
+import { useNavigationStore } from './store';
+import * as S from './styles';
+import { currentPathMatchesRoute } from './utils';
+
+export const PinnedApps = () => {
+  const router = useRouter();
+  const accountId = useAuthStore((store) => store.accountId);
+  const loadPinnedApps = useNavigationStore((store) => store.loadPinnedApps);
+  const pinnedApps = useNavigationStore((store) => store.pinnedApps);
+  const expandedDrawer = useNavigationStore((store) => store.expandedDrawer);
+  const isSidebarExpanded = useNavigationStore((store) => store.isSidebarExpanded && !store.expandedDrawer);
+  const tooltipsDisabled = isSidebarExpanded;
+  const components = useBosComponents();
+  const discoverAppsPath = `/${components.componentsPage}?tab=apps`;
+  const discoverTooltipContent = 'Discover apps to pin';
+
+  const isNavigationItemActive = (route: string | string[], exactMatch = false) => {
+    if (expandedDrawer) return false;
+    return currentPathMatchesRoute(router.asPath, route, exactMatch);
+  };
+
+  useEffect(() => {
+    loadPinnedApps(accountId);
+  }, [accountId, loadPinnedApps]);
+
+  return (
+    <S.Section>
+      <S.SectionLabel>
+        Pinned Apps
+        <Tooltip content={discoverTooltipContent} side="right">
+          <S.SectionLabelIconLink href={discoverAppsPath}>
+            <i className="ph-bold ph-circles-three-plus" />
+          </S.SectionLabelIconLink>
+        </Tooltip>
+      </S.SectionLabel>
+
+      {pinnedApps && pinnedApps.length > 0 ? (
+        <S.Stack $gap="0.5rem">
+          {pinnedApps?.map((app) => (
+            <Tooltip
+              content={app.displayName}
+              side="right"
+              disabled={tooltipsDisabled}
+              key={app.authorAccountId + app.componentName}
+            >
+              <S.NavigationItem
+                $active={isNavigationItemActive(`/${app.authorAccountId}/widget/${app.componentName}`)}
+                $type="featured"
+                href={`/${app.authorAccountId}/widget/${app.componentName}`}
+              >
+                {app.imageUrl ? (
+                  <S.NavigationItemThumbnail>
+                    <img src={app.imageUrl} alt={app.displayName} />
+                  </S.NavigationItemThumbnail>
+                ) : (
+                  <i className="ph-bold ph-app-window" />
+                )}
+                <span>{app.displayName}</span>
+              </S.NavigationItem>
+            </Tooltip>
+          ))}
+        </S.Stack>
+      ) : (
+        <>
+          {isSidebarExpanded ? (
+            <S.Stack $gap="1rem" $frozenWidth>
+              <Text font="text-xs" color="sand11">
+                Discover apps from the NEAR developer community to pin.
+              </Text>
+
+              <Button
+                label="Discover Apps"
+                size="small"
+                variant="secondary"
+                href={discoverAppsPath}
+                className="sidebar-auto-width-button"
+              />
+            </S.Stack>
+          ) : (
+            <S.Stack>
+              <Tooltip content={discoverTooltipContent} side="right" disabled={tooltipsDisabled}>
+                <S.NavigationItem
+                  $active={isNavigationItemActive(discoverAppsPath)}
+                  $type="featured"
+                  href={discoverAppsPath}
+                >
+                  <i className="ph-bold ph-circles-three-plus" />
+                  <span>Discover Apps</span>
+                </S.NavigationItem>
+              </Tooltip>
+            </S.Stack>
+          )}
+        </>
+      )}
+    </S.Section>
+  );
+};

--- a/src/components/sidebar-navigation/Sidebar.tsx
+++ b/src/components/sidebar-navigation/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 
 import { Tooltip } from '../lib/Tooltip';
 import NearIconSvg from './icons/near-icon.svg';
+import { PinnedApps } from './PinnedApps';
 import { useNavigationStore } from './store';
 import * as S from './styles';
 import { currentPathMatchesRoute } from './utils';
@@ -70,6 +71,8 @@ export const Sidebar = () => {
             </Tooltip>
           </S.Stack>
         </S.Section>
+
+        <PinnedApps />
 
         <S.Section>
           <S.SectionLabel>Resources</S.SectionLabel>

--- a/src/components/sidebar-navigation/SmallScreenHeader.tsx
+++ b/src/components/sidebar-navigation/SmallScreenHeader.tsx
@@ -61,23 +61,13 @@ export const SmallScreenHeader = () => {
       )}
 
       {signedIn ? (
-        <>
-          <S.SmallScreenHeaderActions $hidden={isOpenedOnSmallScreens}>
-            <VmComponent
-              showLoadingSpinner={false}
-              src={components.navigation.smallScreenHeader}
-              props={{ availableStorage: availableStorageDisplay, withdrawTokens, logOut }}
-            />
-          </S.SmallScreenHeaderActions>
-
-          <S.SmallScreenHeaderIconButton
-            type="button"
-            aria-label="Expand/Collapse Menu"
-            onClick={toggleExpandedSidebarOnSmallScreens}
-          >
-            <i className={`ph ${isOpenedOnSmallScreens ? 'ph-x' : 'ph-list'}`} />
-          </S.SmallScreenHeaderIconButton>
-        </>
+        <S.SmallScreenHeaderActions $hidden={isOpenedOnSmallScreens}>
+          <VmComponent
+            showLoadingSpinner={false}
+            src={components.navigation.smallScreenHeader}
+            props={{ availableStorage: availableStorageDisplay, withdrawTokens, logOut }}
+          />
+        </S.SmallScreenHeaderActions>
       ) : (
         <Button
           label="Create Account"
@@ -86,6 +76,14 @@ export const SmallScreenHeader = () => {
           style={{ alignSelf: 'center', marginRight: '1rem' }}
         />
       )}
+
+      <S.SmallScreenHeaderIconButton
+        type="button"
+        aria-label="Expand/Collapse Menu"
+        onClick={toggleExpandedSidebarOnSmallScreens}
+      >
+        <i className={`ph ${isOpenedOnSmallScreens ? 'ph-x' : 'ph-list'}`} />
+      </S.SmallScreenHeaderIconButton>
 
       <S.SmallScreenNavigationBackground $expanded={isOpenedOnSmallScreens} />
     </S.SmallScreenHeader>

--- a/src/components/sidebar-navigation/store.ts
+++ b/src/components/sidebar-navigation/store.ts
@@ -1,7 +1,8 @@
 import type { MouseEvent } from 'react';
 import { create } from 'zustand';
 
-import { isSmallScreen, SIDEBAR_EXPANDED_PREFERENCE_KEY } from './utils';
+import type { PinnedApp } from './utils';
+import { fetchPinnedApps, isSmallScreen, PINNED_APPS_CACHE_KEY, SIDEBAR_EXPANDED_PREFERENCE_KEY } from './utils';
 
 export type NavigationDrawer = 'discover' | 'marketing';
 
@@ -12,12 +13,16 @@ type NavigationState = {
   hasInitialized: boolean;
   isOpenedOnSmallScreens: boolean;
   isSidebarExpanded: boolean;
+  pinnedApps: PinnedApp[] | null;
 };
 
 type NavigationStore = NavigationState & {
   initialize: () => void;
   handleBubbledClickInDrawer: () => void;
   handleBubbledClickInSidebar: (event: MouseEvent<HTMLDivElement>) => void;
+  loadPinnedApps: (accountId: string | null) => Promise<void>;
+  modifyPinnedApps: (app: PinnedApp, modification: 'PINNED' | 'UNPINNED') => void;
+  reset: () => void;
   set: (state: Partial<NavigationState>) => void;
   setCurrentPageTitle: (title: string | null) => void;
   setInitialExpandedDrawer: (drawer: NavigationDrawer) => void;
@@ -33,6 +38,7 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   hasInitialized: false,
   isOpenedOnSmallScreens: false,
   isSidebarExpanded: true,
+  pinnedApps: null,
 
   initialize: () => {
     set((state) => {
@@ -68,6 +74,72 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
       }
     });
   },
+
+  loadPinnedApps: async (accountId) => {
+    /*
+      Event if we don't have an accountId yet (wallet state is still resolving on the client side),
+      we can load the previously cached pinned apps instantly to improve perceived performance in 
+      the sidebar. The pinned apps cache is cleared out when the user logs out - which triggers the 
+      reset() action.
+    */
+
+    const cachedPinnedAppsStringified = localStorage.getItem(PINNED_APPS_CACHE_KEY);
+    if (cachedPinnedAppsStringified) {
+      try {
+        const cachedPinnedApps = JSON.parse(cachedPinnedAppsStringified);
+        set({ pinnedApps: cachedPinnedApps });
+      } catch (error) {
+        console.error('Failed to parse cached pinned apps', error);
+      }
+    }
+
+    if (!accountId) return;
+
+    const pinnedApps = await fetchPinnedApps(accountId);
+    localStorage.setItem(PINNED_APPS_CACHE_KEY, JSON.stringify(pinnedApps));
+
+    set({ pinnedApps });
+  },
+
+  modifyPinnedApps: (modifiedApp, modification) => {
+    set((state) => {
+      let pinnedApps = [...(state.pinnedApps || [])];
+
+      if (modification === 'PINNED') {
+        const existingPinnedApp = pinnedApps.find((pinnedApp) => {
+          const pinnedAppId = pinnedApp.authorAccountId + pinnedApp.componentName;
+          const modifiedAppId = modifiedApp.authorAccountId + modifiedApp.componentName;
+          return pinnedAppId === modifiedAppId;
+        });
+
+        if (!existingPinnedApp) {
+          // Avoid adding a duplicate if it's already pinned
+          pinnedApps.push(modifiedApp);
+        }
+      } else if (modification === 'UNPINNED') {
+        pinnedApps = pinnedApps.filter((pinnedApp) => {
+          const pinnedAppId = pinnedApp.authorAccountId + pinnedApp.componentName;
+          const modifiedAppId = modifiedApp.authorAccountId + modifiedApp.componentName;
+          return pinnedAppId !== modifiedAppId;
+        });
+      } else {
+        console.error('Unimplemented modification type in modifyPinnedApps():', modification);
+      }
+
+      localStorage.setItem(PINNED_APPS_CACHE_KEY, JSON.stringify(pinnedApps));
+
+      return {
+        pinnedApps,
+      };
+    });
+  },
+
+  reset: () => {
+    localStorage.removeItem(PINNED_APPS_CACHE_KEY);
+    set({ pinnedApps: null });
+  },
+
+  set: (state) => set(() => state),
 
   setCurrentPageTitle: (currentPageTitle) => set(() => ({ currentPageTitle })),
 
@@ -126,6 +198,4 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
       }
     });
   },
-
-  set: (state) => set(() => state),
 }));

--- a/src/components/sidebar-navigation/styles.ts
+++ b/src/components/sidebar-navigation/styles.ts
@@ -105,13 +105,24 @@ export const Section = styled.div<{
 }>`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
   padding: 1rem;
   border-bottom: 1px solid var(--sand6);
   overflow: hidden;
 
   &:last-child {
     border-bottom: none;
+  }
+
+  .sidebar-auto-width-button {
+    width: 100%;
+  }
+
+  @media (max-width: ${SMALL_SCREEN_LAYOUT_MAX_WIDTH}px) {
+    .sidebar-auto-width-button {
+      width: min-content;
+      white-space: nowrap;
+    }
   }
 
   ${(p) =>
@@ -131,6 +142,37 @@ export const Section = styled.div<{
           }
         `
       : undefined}
+`;
+
+export const NavigationItemThumbnail = styled.div`
+  --outline-color: rgba(0, 0, 0, 0.1);
+  --outline-width: 1px;
+  border-radius: 4px;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 var(--outline-width) var(--outline-color);
+    transition: all 150ms;
+  }
+
+  img {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    border: none;
+    outline: none;
+  }
 `;
 
 export const NavigationItem = styled(Link)<{
@@ -157,10 +199,15 @@ export const NavigationItem = styled(Link)<{
     i {
       background: var(--sand3);
     }
+
+    ${NavigationItemThumbnail} {
+      --outline-color: rgba(0, 0, 0, 0.15);
+    }
   }
 
   &:focus-visible {
-    i {
+    i,
+    ${NavigationItemThumbnail} {
       --outline-color: var(--violet5);
       --outline-width: 2px;
     }
@@ -185,6 +232,8 @@ export const NavigationItem = styled(Link)<{
   }
 
   span {
+    overflow: hidden;
+    text-overflow: ellipsis;
     transition: all var(--sidebar-expand-transition-speed);
   }
 
@@ -194,7 +243,7 @@ export const NavigationItem = styled(Link)<{
           font-weight: 600;
           color: var(--sand12);
           i {
-            --outline-color: var(--sand12);
+            --outline-color: var(--sand12) !important;
             --outline-width: 2px;
           }
         `
@@ -273,20 +322,48 @@ export const NavigationSimpleItem = styled(Link)<{
 `;
 
 export const Stack = styled.div<{
+  $frozenWidth?: boolean;
   $gap?: string;
 }>`
   display: flex;
   flex-direction: column;
   gap: ${(p) => p.$gap ?? '0'};
+  width: ${(p) => (p.$frozenWidth ? 'calc(var(--sidebar-width-expanded) - 2rem)' : undefined)};
 `;
 
 export const SectionLabel = styled.p`
   all: unset;
+  display: flex;
+  align-items: center;
   font: var(--text-xs);
   color: var(--sand12);
   font-weight: 600;
   letter-spacing: 0.24px;
+  white-space: nowrap;
   transition: all var(--sidebar-expand-transition-speed);
+`;
+
+export const SectionLabelIconLink = styled(Link)`
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 20px;
+  color: var(--sand10);
+  text-decoration: none !important;
+  margin-left: auto;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: all 150ms, opacity 0;
+
+  &:hover {
+    color: var(--sand12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--violet5);
+  }
 `;
 
 export const OverflowContainChild = styled.div`
@@ -324,6 +401,7 @@ export const Sidebar = styled.div<{
           }
 
           ${NavigationItem} span,
+          ${SectionLabelIconLink},
           ${SectionLabel},
           ${Logo} {
             pointer-events: none;
@@ -333,7 +411,7 @@ export const Sidebar = styled.div<{
           }
 
           ${SectionLabel} {
-            margin-bottom: -1.5rem;
+            margin-bottom: -2rem;
           }
         `}
 

--- a/src/components/sidebar-navigation/utils.ts
+++ b/src/components/sidebar-navigation/utils.ts
@@ -49,9 +49,7 @@ export async function fetchPinnedApps(accountId: string) {
           authorAccountId,
           componentName,
           displayName: metadata.name || componentName,
-          imageUrl: metadata.image?.ipfs_cid
-            ? `https://i.near.social/large/https://ipfs.near.social/ipfs/${metadata.image.ipfs_cid}`
-            : null,
+          imageUrl: metadata.image?.ipfs_cid ? `https://ipfs.near.social/ipfs/${metadata.image.ipfs_cid}` : null,
         });
       });
     });

--- a/src/components/sidebar-navigation/utils.ts
+++ b/src/components/sidebar-navigation/utils.ts
@@ -1,5 +1,6 @@
 export const SMALL_SCREEN_LAYOUT_MAX_WIDTH = 1240;
 export const SIDEBAR_EXPANDED_PREFERENCE_KEY = 'sidebar-expanded-preference';
+export const PINNED_APPS_CACHE_KEY = 'pinned-apps-cache';
 
 export function currentPathMatchesRoute(currentPath: string, routeMatch: string | string[], exactMatch = true) {
   const path = currentPath.split('?').shift() ?? '/';
@@ -12,4 +13,51 @@ export function currentPathMatchesRoute(currentPath: string, routeMatch: string 
 export function isSmallScreen() {
   if (typeof window === 'undefined') return false;
   return window.innerWidth <= SMALL_SCREEN_LAYOUT_MAX_WIDTH;
+}
+
+export type PinnedApp = {
+  authorAccountId: string;
+  displayName: string;
+  componentName: string;
+  imageUrl: string | null;
+};
+
+export async function fetchPinnedApps(accountId: string) {
+  const result: PinnedApp[] = [];
+
+  try {
+    const pinnedKeys = `${accountId}/graph/pin/*/widget/*`;
+    const pinnedResponse = await fetch(`https://api.near.social/get?keys=${pinnedKeys}`);
+    const pinnedJson = await pinnedResponse.json();
+    const pinnedData = pinnedJson[accountId]?.graph?.pin ?? {};
+
+    const componentsKeys: string[] = [];
+    Object.keys(pinnedData).forEach((authorAccountId) => {
+      Object.keys(pinnedData[authorAccountId].widget).forEach((componentName) => {
+        componentsKeys.push(`${authorAccountId}/widget/${componentName}/metadata/**`);
+      });
+    });
+
+    if (componentsKeys.length === 0) return result;
+
+    const componentsResponse = await fetch(`https://api.near.social/get?keys=${componentsKeys.join('&keys=')}`);
+    const componentsJson = await componentsResponse.json();
+    Object.keys(componentsJson).forEach((authorAccountId) => {
+      Object.keys(componentsJson[authorAccountId].widget).forEach((componentName) => {
+        const metadata = componentsJson[authorAccountId].widget[componentName].metadata ?? {};
+        result.push({
+          authorAccountId,
+          componentName,
+          displayName: metadata.name || componentName,
+          imageUrl: metadata.image?.ipfs_cid
+            ? `https://i.near.social/large/https://ipfs.near.social/ipfs/${metadata.image.ipfs_cid}`
+            : null,
+        });
+      });
+    });
+  } catch (error) {
+    console.error('pinned', 'Failed to fetch pinned apps', error);
+  }
+
+  return result;
 }

--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -52,6 +52,8 @@ import {
 } from '@/utils/config';
 import { KEYPOM_OPTIONS } from '@/utils/keypom-options';
 
+import { useNavigationStore } from '../sidebar-navigation/store';
+
 export default function VmInitializer() {
   const [signedIn, setSignedIn] = useState(false);
   const [signedAccountId, setSignedAccountId] = useState(null);
@@ -68,6 +70,7 @@ export default function VmInitializer() {
   const { requestAuthentication, saveCurrentUrl } = useSignInRedirect();
   const idOS = useIdOS();
   const idosSDK = useIdosStore((state) => state.idOS);
+  const resetNavigation = useNavigationStore((store) => store.reset);
 
   useEffect(() => {
     initNear &&
@@ -222,8 +225,9 @@ export default function VmInitializer() {
     setSignedIn(false);
     setSignedAccountId(null);
     resetAnalytics();
+    resetNavigation();
     localStorage.removeItem('accountId');
-  }, [idosSDK, near]);
+  }, [idosSDK, near, resetNavigation]);
 
   const refreshAllowance = useCallback(async () => {
     alert("You're out of access key allowance. Need sign in again to refresh it");

--- a/src/hooks/useGatewayEvents.ts
+++ b/src/hooks/useGatewayEvents.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+
+import { useNavigationStore } from '@/components/sidebar-navigation/store';
+import type { PinnedApp } from '@/components/sidebar-navigation/utils';
+
+type PinnedAppsGatewayEvent = {
+  type: 'PINNED_APPS';
+  app: PinnedApp;
+  modification: 'PINNED' | 'UNPINNED';
+};
+
+type GenericGatewayEvent = {
+  type: 'GENERIC';
+  data: any;
+};
+
+type GatewayEvent = GenericGatewayEvent | PinnedAppsGatewayEvent;
+
+export function useGatewayEvents() {
+  /*
+    Since the exports of this hook will be passed into BOS/VM components, it's important 
+    to only expose methods that rely on useCallback() to reduce re-renders for the VM.
+  */
+
+  const modifyPinnedApps = useNavigationStore((store) => store.modifyPinnedApps);
+
+  const handleGenericEvent = useCallback((event: GenericGatewayEvent) => {
+    /* 
+      This event doesn't have a use case right now, but it serves as an example of 
+      how we could implement different event types in the future.
+    */
+
+    console.log('Generic gateway event recorded with data:', event);
+  }, []);
+
+  const handlePinnedAppsEvent = useCallback(
+    (event: PinnedAppsGatewayEvent) => {
+      modifyPinnedApps(event.app, event.modification);
+    },
+    [modifyPinnedApps],
+  );
+
+  const emitGatewayEvent = useCallback(
+    (event: GatewayEvent) => {
+      switch (event.type) {
+        case 'GENERIC':
+          handleGenericEvent(event);
+          break;
+        case 'PINNED_APPS':
+          handlePinnedAppsEvent(event);
+          break;
+        default:
+          console.error('Unimplemented gateway event recorded:', event);
+      }
+    },
+    [handleGenericEvent, handlePinnedAppsEvent],
+  );
+
+  return { emitGatewayEvent };
+}

--- a/src/pages/[componentAccountId]/widget/[componentName].tsx
+++ b/src/pages/[componentAccountId]/widget/[componentName].tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { RootContentContainer } from '@/components/lib/Container';
 import { VmComponent } from '@/components/vm/VmComponent';
 import { useBosComponents } from '@/hooks/useBosComponents';
+import { useGatewayEvents } from '@/hooks/useGatewayEvents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useSignInRedirect } from '@/hooks/useSignInRedirect';
 import { useAuthStore } from '@/stores/auth';
@@ -19,6 +20,7 @@ const ViewComponentPage: NextPageWithLayout = () => {
   const authStore = useAuthStore();
   const components = useBosComponents();
   const { requestAuthentication } = useSignInRedirect();
+  const { emitGatewayEvent } = useGatewayEvents();
 
   useEffect(() => {
     const { requestAuth, createAccount } = componentProps;
@@ -41,6 +43,7 @@ const ViewComponentPage: NextPageWithLayout = () => {
         key={components.wrapper}
         src={components.wrapper}
         props={{
+          emitGatewayEvent,
           logOut: authStore.logOut,
           targetProps: componentProps,
           targetComponent: componentSrc,

--- a/src/pages/[componentAccountId]/widget/[componentName].tsx
+++ b/src/pages/[componentAccountId]/widget/[componentName].tsx
@@ -20,7 +20,7 @@ const ViewComponentPage: NextPageWithLayout = () => {
   const authStore = useAuthStore();
   const components = useBosComponents();
   const { requestAuthentication } = useSignInRedirect();
-  const { emitGatewayEvent } = useGatewayEvents();
+  const { emitGatewayEvent, shouldPassGatewayEventProps } = useGatewayEvents();
 
   useEffect(() => {
     const { requestAuth, createAccount } = componentProps;
@@ -43,7 +43,9 @@ const ViewComponentPage: NextPageWithLayout = () => {
         key={components.wrapper}
         src={components.wrapper}
         props={{
-          emitGatewayEvent,
+          emitGatewayEvent: shouldPassGatewayEventProps(router.query.componentAccountId as string)
+            ? emitGatewayEvent
+            : undefined,
           logOut: authStore.logOut,
           targetProps: componentProps,
           targetComponent: componentSrc,

--- a/src/pages/embed/[accountId]/widget/[componentName].tsx
+++ b/src/pages/embed/[accountId]/widget/[componentName].tsx
@@ -18,7 +18,7 @@ const EmbedComponentPage: NextPageWithLayout = () => {
   const setComponentSrc = useCurrentComponentStore((store) => store.setSrc);
   const componentSrc = `${router.query.accountId}/widget/${router.query.componentName}`;
   const [componentProps, setComponentProps] = useState<Record<string, unknown>>({});
-  const { emitGatewayEvent } = useGatewayEvents();
+  const { emitGatewayEvent, shouldPassGatewayEventProps } = useGatewayEvents();
 
   useEffect(() => {
     setComponentSrc(componentSrc);
@@ -34,7 +34,9 @@ const EmbedComponentPage: NextPageWithLayout = () => {
         key={components.wrapper}
         src={components.wrapper}
         props={{
-          emitGatewayEvent,
+          emitGatewayEvent: shouldPassGatewayEventProps(router.query.accountId as string)
+            ? emitGatewayEvent
+            : undefined,
           logOut: authStore.logOut,
           targetComponent: componentSrc,
           targetProps: componentProps,

--- a/src/pages/embed/[accountId]/widget/[componentName].tsx
+++ b/src/pages/embed/[accountId]/widget/[componentName].tsx
@@ -1,8 +1,10 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
+import { RootContentContainer } from '@/components/lib/Container';
 import { VmComponent } from '@/components/vm/VmComponent';
 import { useBosComponents } from '@/hooks/useBosComponents';
+import { useGatewayEvents } from '@/hooks/useGatewayEvents';
 import { useSimpleLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useCurrentComponentStore } from '@/stores/current-component';
@@ -16,6 +18,7 @@ const EmbedComponentPage: NextPageWithLayout = () => {
   const setComponentSrc = useCurrentComponentStore((store) => store.setSrc);
   const componentSrc = `${router.query.accountId}/widget/${router.query.componentName}`;
   const [componentProps, setComponentProps] = useState<Record<string, unknown>>({});
+  const { emitGatewayEvent } = useGatewayEvents();
 
   useEffect(() => {
     setComponentSrc(componentSrc);
@@ -26,11 +29,12 @@ const EmbedComponentPage: NextPageWithLayout = () => {
   }, [router.query]);
 
   return (
-    <div className="d-inline-block position-relative overflow-hidden">
+    <RootContentContainer>
       <VmComponent
         key={components.wrapper}
         src={components.wrapper}
         props={{
+          emitGatewayEvent,
           logOut: authStore.logOut,
           targetComponent: componentSrc,
           targetProps: componentProps,
@@ -38,7 +42,7 @@ const EmbedComponentPage: NextPageWithLayout = () => {
           privacyDomainName,
         }}
       />
-    </div>
+    </RootContentContainer>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage
 import { NotificationsAlert } from '@/components/NotificationsAlert';
 import { useSidebarLayoutEnabled } from '@/components/sidebar-navigation/hooks';
 import { useBosComponents } from '@/hooks/useBosComponents';
+import { useGatewayEvents } from '@/hooks/useGatewayEvents';
 import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useCurrentComponentStore } from '@/stores/current-component';
@@ -24,6 +25,7 @@ const HomePage: NextPageWithLayout = () => {
   const logOut = useAuthStore((store) => store.logOut);
   const setTosData = useTermsOfServiceStore((store) => store.setTosData);
   const { sidebarLayoutEnabled } = useSidebarLayoutEnabled();
+  const { emitGatewayEvent } = useGatewayEvents();
 
   useEffect(() => {
     const optimisticAccountId = window.localStorage.getItem(localStorageAccountIdKey);
@@ -59,6 +61,7 @@ const HomePage: NextPageWithLayout = () => {
         <ComponentWrapperPage
           src={components.wrapper}
           componentProps={{
+            emitGatewayEvent,
             logOut,
             targetProps: router.query,
             targetComponent: sidebarLayoutEnabled ? components.gateway.homePage : components.default,

--- a/src/pages/s/[urlShareIndicator].tsx
+++ b/src/pages/s/[urlShareIndicator].tsx
@@ -48,7 +48,7 @@ type ShareType = 'POST' | 'COMMENT' | 'INVALID';
 
 function returnImageUrl(data: ImageData | undefined) {
   if (data?.ipfs_cid) {
-    return `https://i.near.social/large/https://ipfs.near.social/ipfs/${data.ipfs_cid}`;
+    return `https://ipfs.near.social/ipfs/${data.ipfs_cid}`;
   }
   return null;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,7 +42,7 @@ a:hover {
 }
 
 #near-wallet-selector-modal .open {
-  z-index: 1001;
+  z-index: 5000;
 }
 
 #idos_container {


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery/issues/1056

- Implement pinned apps in the new sidebar layout. Since our sidebar layout is still not enabled, you'll need to test the preview link by adding `?sidebar=true` to the end of your URL. The pinned UI on the `ComponentDetailsPage` and `ProfilePage` will only be visible if the sidebar layout is enabled.
- Implement  generic hook and pattern for passing events and data between the gateway and BOS components via `useGatewayEvents()`. This allows our trusted BOS components to emit an event to the gateway when an app is pinned or unpinned. This allows us to update the sidebar UI optimistically as soon as a user clicks on pin or unpin.
- When pinned apps are loaded or modified, they are cached in `localStorage` to provide an instant loading experience in the sidebar when initially loading the page. The pinned apps are fetched from Social DB on page load and will eventually update your UI and `localStorage` once the request finishes to always be in sync with what's actually stored on chain (follows the stale-while-revalidate pattern).
- The `useGatewayEvents()` hook can hopefully be useful for other features down the road.
- Updated our `Star` and `Pin` actions to show descriptive tooltips on hover. When a user isn't signed in yet, the tooltips will notify the user that they need to sign in first.

To test the UI/UX flow:

- Will rely on BOS component changes in the 1st PR over here: https://github.com/near/near-discovery-components/pull/743
- Open the test preview and add `?sidebar=true` to the URL and go visit the `ComponentDetailsPage` for any component.
- Here's a good example: `/near/widget/ComponentDetailsPage?src=potlock.near/widget/Index&sidebar=true`
- Try pinning and unpinning a few apps. They should instantly appear and/or disappear from the sidebar as you pin/unpin.
- Visit your profile page to see a `Pins (X)` tab: `/near/widget/ProfilePage?accountId=calebjacob.near&sidebar=true`
- From there you can click on a card to then view the `ComponentDetailsPage` to unpin the app.