### PR TITLE
Fix ?sidebar=true test flag

### DIFF
--- a/src/components/sidebar-navigation/hooks.ts
+++ b/src/components/sidebar-navigation/hooks.ts
@@ -1,11 +1,23 @@
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 import { sidebarLayoutEnabled as sidebarLayoutFeatureFlagEnabled } from '@/utils/config';
 
 export function useSidebarLayoutEnabled() {
   const router = useRouter();
-  const sidebarLayoutTestOverrideEnabled = router.query.sidebar === 'true';
+  const [sidebarLayoutTestOverrideEnabled, setSidebarLayoutTestOverrideEnabled] = useState(false);
   const sidebarLayoutEnabled = sidebarLayoutTestOverrideEnabled || sidebarLayoutFeatureFlagEnabled;
+
+  useEffect(() => {
+    /*
+      We only evaluate this once on page load so that we keep it enabled until they close
+      their browser tab.
+    */
+
+    setSidebarLayoutTestOverrideEnabled(router.query.sidebar === 'true');
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /*
     The sidebarLayoutTestOverrideEnabled logic is only needed for short term testing.


### PR DESCRIPTION
I made a change recently to simplify `?sidebar=true`, but didn't realize it introduced a new issue with the feature reverting after clicking on a link. This fixes that.