### PR TITLE
chore: set pnpm version for CI to 8.5.1

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 8.5.1
       - uses: actions/setup-node@v3
         with:
           node-version: 20
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 8.5.1
       - uses: actions/setup-node@v3
         with:
           node-version: 20


### PR DESCRIPTION
Our `pnpm install` and `prettier` CI actions were set to use the latest version of `pnpm`. This PR fixes the failures that our lockfile has with version 9+ of pnpm. 