### PR TITLE
feat: ai page and menu item

### DIFF
--- a/src/components/marketing-navigation/categories.ts
+++ b/src/components/marketing-navigation/categories.ts
@@ -105,6 +105,11 @@ export const navigationCategories = [
             url: '/gateways',
             icon: 'ph-compass ph-bold',
           },
+          {
+            title: 'AI',
+            url: '/ai',
+            icon: 'ph-sparkle ph-bold',
+          },
         ],
       },
     ],

--- a/src/components/sidebar-navigation/sections.ts
+++ b/src/components/sidebar-navigation/sections.ts
@@ -28,6 +28,11 @@ export const discoverDrawerSections: NavigationSection[] = [
         url: '/gateways',
         icon: 'ph-compass',
       },
+      {
+        title: 'AI',
+        url: '/ai',
+        icon: 'ph-sparkle',
+      },
     ],
   },
 ];

--- a/src/data/bos-components.ts
+++ b/src/data/bos-components.ts
@@ -2,6 +2,7 @@ import type { NetworkId } from '@/utils/types';
 
 type NetworkComponents = {
   activityPage: string;
+  aiPage: string;
   applicationsPage: string;
   blog: string;
   blogPost: string;
@@ -84,6 +85,7 @@ export const componentsByNetworkId = ((): Record<NetworkId, NetworkComponents | 
   return {
     testnet: {
       activityPage: `${testnetTLA}/widget/ActivityPage`,
+      aiPage: `${testnetTLA}/widget/AI.Nexus`,
       applicationsPage: `${testnetTLA}/widget/AppLibrary.IndexPage`,
       blog: `${testnetTLA}/widget/Blog/Feed`,
       blogPost: `${testnetTLA}/widget/BlogPostPage`,
@@ -159,6 +161,7 @@ export const componentsByNetworkId = ((): Record<NetworkId, NetworkComponents | 
 
     mainnet: {
       activityPage: 'near/widget/ActivityPage',
+      aiPage: 'near/widget/AI.Nexus',
       applicationsPage: 'nearcatalog.near/widget/Index',
       blog: 'near/widget/Blog.Feed',
       blogPost: 'near/widget/BlogPostPage',

--- a/src/pages/ai.tsx
+++ b/src/pages/ai.tsx
@@ -1,0 +1,23 @@
+import { ComponentWrapperPage } from '@/components/near-org/ComponentWrapperPage';
+import { useBosComponents } from '@/hooks/useBosComponents';
+import { useDefaultLayout } from '@/hooks/useLayout';
+import type { NextPageWithLayout } from '@/utils/types';
+
+const ComponentsPage: NextPageWithLayout = () => {
+  const components = useBosComponents();
+
+  return (
+    <ComponentWrapperPage
+      src={components.aiPage}
+      componentProps={{}}
+      meta={{
+        title: 'AI is NEAR',
+        description: 'Find Agents, Datasets, Models, Frameworks, build your own or customize AI to work for you.',
+      }}
+    />
+  );
+};
+
+ComponentsPage.getLayout = useDefaultLayout;
+
+export default ComponentsPage;


### PR DESCRIPTION
/ai routes to widget/near/AI.Nexus
AI top and sidebar menu item in Discover menu


Top menu screenshot
![Screenshot 2024-04-23 at 12 35 45 PM](https://github.com/near/near-discovery/assets/671506/25ba4e62-649f-4657-a019-fdf39c84b894)


Sidebar screenshot
![Screenshot 2024-04-23 at 12 34 52 PM](https://github.com/near/near-discovery/assets/671506/d6385a76-b5d4-4a5e-83f7-3b6fe573b589)
