### PR TITLE
chore: update commit script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm prettier
+pnpm prettier && pnpm lint

--- a/src/pages/s/[urlShareIndicator].tsx
+++ b/src/pages/s/[urlShareIndicator].tsx
@@ -1,6 +1,7 @@
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+
 import { openToast } from '@/components/lib/Toast';
 import { MetaTags } from '@/components/MetaTags';
 import { useDefaultLayout } from '@/hooks/useLayout';
@@ -107,7 +108,7 @@ function parseMarkdown(markdown: string) {
     line = line.trim();
     if (index === 0 && isImage(line)) {
       headerImageUrl = getImageUrl(line);
-      parsedMarkdown.push({ type: 'header-image', imageUrl: getImageUrl(line) });
+      parsedMarkdown.push({ type: 'header-image', imageUrl: headerImageUrl });
     } else if (line.startsWith('#')) {
       listType = null;
       const match = line.match(/^#+/);


### PR DESCRIPTION
Seems like we didn't use `pnpm lint` along with `pre-commit` script. That's why some warnings could be missed. This PR introduces changes to `pre-commit` script to make sure our project aligned with our prettier and linter rules