### PR TITLE
feat: allow for gateway to pass in url for bosblog component

### DIFF
--- a/src/pages/bosblog/index.tsx
+++ b/src/pages/bosblog/index.tsx
@@ -13,6 +13,7 @@ const Blog: NextPageWithLayout = () => {
   const accountId = router.query.accountId;
   const blockHeight = router.query.blockHeight;
   const contributors = ['near', 'jacksonthedev.near'];
+  const blogComponentUrl = 'bosblog'; // the url of the blog component for a given gateway
 
   if (accountId && blockHeight) {
     return (
@@ -26,7 +27,7 @@ const Blog: NextPageWithLayout = () => {
           requestAuthentication,
           accountId,
           blockHeight,
-          includeFooter: true,
+          blogComponentUrl,
         }}
       />
     );

--- a/src/pages/bosblog/index.tsx
+++ b/src/pages/bosblog/index.tsx
@@ -27,6 +27,7 @@ const Blog: NextPageWithLayout = () => {
           requestAuthentication,
           accountId,
           blockHeight,
+          includeFooter: true,
           blogComponentUrl,
         }}
       />


### PR DESCRIPTION
Closes: [Blog.Feed](https://github.com/orgs/near/projects/92/views/6?pane=issue&itemId=61052380) Allowing for a gateway to set the url for its blog component.