### PR TITLE
adds a 'View Component' alternative for dev.near.org

### DIFF
--- a/src/components/sidebar-navigation/MarketingDrawer.tsx
+++ b/src/components/sidebar-navigation/MarketingDrawer.tsx
@@ -5,6 +5,8 @@ import { marketingDrawerSections } from './sections';
 import { useNavigationStore } from './store';
 import * as S from './styles';
 import { currentPathMatchesRoute } from './utils';
+import { useCurrentComponentStore } from '@/stores/current-component';
+import { useEffect } from 'react';
 
 type Props = {
   expanded: boolean;
@@ -15,6 +17,7 @@ export const MarketingDrawer = ({ expanded }: Props) => {
   const isOpenedOnSmallScreens = useNavigationStore((store) => store.isOpenedOnSmallScreens);
   const handleBubbledClickInDrawer = useNavigationStore((store) => store.handleBubbledClickInDrawer);
   const setInitialExpandedDrawer = useNavigationStore((store) => store.setInitialExpandedDrawer);
+  const currentComponentSrc = useCurrentComponentStore((store) => store.src);
 
   const isNavigationItemActive = (route: string | string[]) => {
     const isActive = currentPathMatchesRoute(router.asPath, route);
@@ -23,6 +26,21 @@ export const MarketingDrawer = ({ expanded }: Props) => {
     });
     return isActive;
   };
+
+  useEffect(() => {
+    const developLinks = marketingDrawerSections[1].links;
+    const isComponentURL = () => ['/widget/', '/component/'].some((p) => router.asPath.indexOf(p) !== -1);
+
+    if (currentComponentSrc && developLinks.length === 5) {
+      developLinks.unshift({
+        title: 'Inspect Component',
+        url: `/near/widget/ComponentDetailsPage?src=${currentComponentSrc}`,
+        icon: 'ph-magnifying-glass ph-bold',
+      });
+    } else if (!isComponentURL() && !currentComponentSrc && developLinks.length === 6) {
+      developLinks.shift();
+    }
+  }, [currentComponentSrc, router]);
 
   return (
     <S.Drawer $expanded={expanded} $openedOnSmallScreens={isOpenedOnSmallScreens} onClick={handleBubbledClickInDrawer}>


### PR DESCRIPTION
 a somewhat clunky workaround for dev.near.org to provide quick access to view the details of the currently in view BOS component since the following onhover menu option is not part of this UI. 
 
<img width="574" alt="Screen Shot 2024-05-17 at 9 51 51 AM" src="https://github.com/near/near-discovery/assets/1915116/0c4e3861-1ff9-4f24-8729-7e6e4395e6d9">



That implementation would show & hide that menu based on the user's onhover action, was was a convenient rerender hook that we used to check if the current view contained a bos component. The new menu is more static, and the result in this workaround is that the  More -> Develop menu's `Inspect Component` option may appear event when a non-bos component is in view like [dev.near.org/sandbox](https://dev.near.org/sandbox)

<img width="371" alt="Screen Shot 2024-05-17 at 9 56 29 AM" src="https://github.com/near/near-discovery/assets/1915116/ef2158c4-0391-4519-81a3-d5058e067fc9">
