### PR TITLE
chore: add idos create account link (2 of 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ NEXT_PUBLIC_COMMIT_MODAL_BYPASS_AUTHOR_IDS=near,discom.testnet,discom-dev.testne
 NEXT_PUBLIC_COMMIT_MODAL_BYPASS_SOURCES=
 # sidebar or marketing layout
 NEXT_PUBLIC_SIDEBAR_LAYOUT=true
+NEXT_PUBLIC_IDOS_CREATE_ACCOUNT_URL="https://app.fractal.id/authorize?client_id=PXAbBxPErSPMXiKmMYQ3ged8Qxwqg1Px7ymhsuhaGP4&redirect_uri=https%3A%2F%2Fdev.near.org%2Fsettings&response_type=code&scope=contact%3Aread%20verification.uniqueness%3Aread%20verification.uniqueness.details%3Aread%20verification.idos%3Aread%20verification.idos.details%3Aread%20verification.wallet-near%3Aread%20verification.wallet-near.details%3Aread"

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -13,6 +13,7 @@ import { useDefaultLayout } from '@/hooks/useLayout';
 import { useAuthStore } from '@/stores/auth';
 import { useIdosStore } from '@/stores/idosStore';
 import { recordHandledError } from '@/utils/analytics';
+import { idosCreateAccountUrl } from '@/utils/config';
 import type { NextPageWithLayout } from '@/utils/types';
 
 const SettingsPage: NextPageWithLayout = () => {
@@ -83,6 +84,7 @@ const SettingsPage: NextPageWithLayout = () => {
         showTooltip: false,
         walletImages,
         connectedWallet: !accountId ? undefined : connectedWallet,
+        idosCreateAccountUrl, // originally, this should came from idOS maybe we should change it someday
       }}
     />
   );

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -67,6 +67,7 @@ export const isLocalEnvironment = process.env.NEXT_PUBLIC_LOCAL_ENVIRONMENT === 
 export const eventsApiUrl = process.env.NEXT_PUBLIC_EVENTS_API_URL;
 export const eventsApiKey = process.env.NEXT_PUBLIC_EVENTS_API_KEY;
 export const sidebarLayoutEnabled = process.env.NEXT_PUBLIC_SIDEBAR_LAYOUT === 'true';
+export const idosCreateAccountUrl = process.env.NEXT_PUBLIC_IDOS_CREATE_ACCOUNT_URL;
 
 export const commitModalBypassAuthorIds = (process.env.NEXT_PUBLIC_COMMIT_MODAL_BYPASS_AUTHOR_IDS ?? '')
   .split(',')


### PR DESCRIPTION
This PR introduces a new environment variable called `NEXT_PUBLIC_IDOS_CREATE_ACCOUNT_URL` to have an opportunity to change the idos create account url in a few seconds (if needed)

Part 1: https://github.com/near/near-discovery-components/pull/821