### PR TITLE
chore: reduce amount of search categories (Part 2/2)

### DIFF
--- a/src/components/layouts/DefaultLayout.tsx
+++ b/src/components/layouts/DefaultLayout.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { BosLoaderBanner } from '../BosLoaderBanner';
 import { MarketingNavigation } from '../marketing-navigation/MarketingNavigation';
 import { useSidebarLayoutEnabled } from '../sidebar-navigation/hooks';
-import { LargeScreenHeader } from '../sidebar-navigation/LargeScreenHeader';
+// import { LargeScreenHeader } from '../sidebar-navigation/LargeScreenHeader';
 import { SidebarNavigation } from '../sidebar-navigation/SidebarNavigation';
 import { useNavigationStore } from '../sidebar-navigation/store';
 import { SMALL_SCREEN_LAYOUT_MAX_WIDTH } from '../sidebar-navigation/utils';
@@ -70,7 +70,7 @@ export function DefaultLayout({ children }: Props) {
       {sidebarLayoutEnabled ? <SidebarNavigation /> : <MarketingNavigation />}
 
       <Content>
-        {sidebarLayoutEnabled && <LargeScreenHeader />}
+        {/* {sidebarLayoutEnabled && <LargeScreenHeader />} */}
 
         <BosLoaderBanner />
 

--- a/src/components/layouts/DefaultLayout.tsx
+++ b/src/components/layouts/DefaultLayout.tsx
@@ -70,7 +70,7 @@ export function DefaultLayout({ children }: Props) {
       {sidebarLayoutEnabled ? <SidebarNavigation /> : <MarketingNavigation />}
 
       <Content>
-        {/* {sidebarLayoutEnabled && <LargeScreenHeader />} */}
+        {sidebarLayoutEnabled && <LargeScreenHeader />}
 
         <BosLoaderBanner />
 

--- a/src/components/sidebar-navigation/LargeScreenHeader.tsx
+++ b/src/components/sidebar-navigation/LargeScreenHeader.tsx
@@ -6,7 +6,6 @@ import { useAuthStore } from '@/stores/auth';
 
 import { Button } from '../lib/Button';
 import { VmComponent } from '../vm/VmComponent';
-import { LargeScreenNotificationButton } from './LargeScreenNotificationButton';
 import { LargeScreenProfileDropdown } from './LargeScreenProfileDropdown';
 import { useNavigationStore } from './store';
 import * as S from './styles';
@@ -47,7 +46,6 @@ export const LargeScreenHeader = () => {
           title: currentPageTitle,
           rightSideChildren: signedIn ? (
             <>
-              <LargeScreenNotificationButton />
               <LargeScreenProfileDropdown />
             </>
           ) : (

--- a/src/components/sidebar-navigation/LargeScreenProfileDropdown.tsx
+++ b/src/components/sidebar-navigation/LargeScreenProfileDropdown.tsx
@@ -20,7 +20,7 @@ export const LargeScreenProfileDropdown = () => {
   }, [near]);
 
   return (
-    <S.LargeScreenHeaderActionWrapper>
+    <S.LargeScreenHeaderActionWrapper $width="100%" $justifyContent="start">
       <VmComponent
         src={components.navigation.profileDropdown}
         props={{

--- a/src/components/sidebar-navigation/Search.tsx
+++ b/src/components/sidebar-navigation/Search.tsx
@@ -1,0 +1,18 @@
+import { useBosComponents } from '@/hooks/useBosComponents';
+
+import { VmComponent } from '../vm/VmComponent';
+import * as S from './styles';
+
+export const Search = () => {
+  const components = useBosComponents();
+  return (
+    <S.SearchWrapper>
+      <VmComponent
+        src={components.navigation.search}
+        props={{
+          placeholder: 'Search for apps...',
+        }}
+      />
+    </S.SearchWrapper>
+  );
+};

--- a/src/components/sidebar-navigation/Sidebar.tsx
+++ b/src/components/sidebar-navigation/Sidebar.tsx
@@ -3,14 +3,9 @@ import { useRouter } from 'next/router';
 
 import { Tooltip } from '../lib/Tooltip';
 import NearIconSvg from './icons/near-icon.svg';
-// import { PinnedApps } from './PinnedApps';
 import { useNavigationStore } from './store';
 import * as S from './styles';
 import { currentPathMatchesRoute } from './utils';
-import { LargeScreenProfileDropdown } from './LargeScreenProfileDropdown';
-import { LargeScreenNameDropdown } from './LargeScreenNameDropdown';
-import { useSignInRedirect } from '@/hooks/useSignInRedirect';
-import { useAuthStore } from '@/stores/auth';
 
 export const Sidebar = () => {
   const router = useRouter();
@@ -18,16 +13,8 @@ export const Sidebar = () => {
   const isSidebarExpanded = useNavigationStore((store) => store.isSidebarExpanded && !store.expandedDrawer);
   const isOpenedOnSmallScreens = useNavigationStore((store) => store.isOpenedOnSmallScreens);
   const toggleExpandedSidebar = useNavigationStore((store) => store.toggleExpandedSidebar);
-  // const toggleExpandedDrawer = useNavigationStore((store) => store.toggleExpandedDrawer);
   const handleBubbledClickInSidebar = useNavigationStore((store) => store.handleBubbledClickInSidebar);
-  const { requestAuthentication } = useSignInRedirect();
   const tooltipsDisabled = isSidebarExpanded;
-  const signedIn = useAuthStore((store) => store.signedIn);
-  const signedAccountId = useAuthStore((store) => store.accountId);
-
-  const handleSignIn = () => {
-    requestAuthentication(true);
-  };
 
   const isNavigationItemActive = (route: string | string[], exactMatch = false) => {
     if (expandedDrawer) return false;
@@ -60,12 +47,6 @@ export const Sidebar = () => {
               </S.NavigationItem>
             </Tooltip>
 
-            {/* <Tooltip content="Activity" side="right" disabled={tooltipsDisabled}>
-              <S.NavigationItem $active={isNavigationItemActive('/activity')} $type="featured" href="/activity">
-                <i className="ph-bold ph-pulse" />
-                <span>Activity</span>
-              </S.NavigationItem>
-            </Tooltip> */}
             <Tooltip content="Documentation" side="right" disabled={tooltipsDisabled}>
               <S.NavigationItem
                 $active={isNavigationItemActive('/documentation')}
@@ -83,24 +64,8 @@ export const Sidebar = () => {
                 <span>Support</span>
               </S.NavigationItem>
             </Tooltip>
-
-            {/* <Tooltip content="Discover" side="right" disabled={tooltipsDisabled}>
-              <S.NavigationItem
-                as="button"
-                type="button"
-                $active={isNavigationItemActive(['/applications', '/components', '/gateways'])}
-                $expanded={expandedDrawer === 'discover'}
-                $type="featured"
-                onClick={(event) => toggleExpandedDrawer('discover', event)}
-              >
-                <i className="ph-bold ph-shapes" />
-                <span>Discover</span>
-              </S.NavigationItem>
-            </Tooltip> */}
           </S.Stack>
         </S.Section>
-
-        {/* <PinnedApps /> */}
 
         <S.Section>
           <S.SectionLabel>Discover </S.SectionLabel>
@@ -120,20 +85,6 @@ export const Sidebar = () => {
                 <span className="ph-bold ph-arrow-square-out ms-auto outline-none" />
               </S.NavigationItem>
             </Tooltip>
-
-            {/* <Tooltip content="More" side="right" disabled={tooltipsDisabled}>
-              <S.NavigationItem
-                as="button"
-                type="button"
-                $active={false}
-                $expanded={expandedDrawer === 'marketing'}
-                $type="featured"
-                onClick={(event) => toggleExpandedDrawer('marketing', event)}
-              >
-                <i className="ph-bold ph-dots-three-outline-vertical" />
-                <span>More</span>
-              </S.NavigationItem>
-            </Tooltip> */}
 
             <Tooltip content="News" side="right" disabled={tooltipsDisabled}>
               <S.NavigationItem
@@ -196,31 +147,6 @@ export const Sidebar = () => {
             </Tooltip>
           </S.Stack>
         </S.Section>
-
-        {/* TODO: Improve handling the sidebar opening */}
-        <S.LoginSection
-          onFocus={() => {
-            !isSidebarExpanded && toggleExpandedSidebar();
-          }}
-        >
-          {signedIn ? (
-            <Tooltip content={signedAccountId} side="right" disabled={tooltipsDisabled}>
-              <S.LoginItem $active={false} $type="featured">
-                <LargeScreenProfileDropdown />
-                <LargeScreenNameDropdown />
-              </S.LoginItem>
-            </Tooltip>
-          ) : (
-            <Tooltip content="Sign-up or Login" side="right" disabled={tooltipsDisabled}>
-              <S.LoginItem $active={false} $type="featured" onClick={handleSignIn}>
-                <i className="ph-bold ph-keyhole" />
-                <span>Sign-up or Login</span>
-              </S.LoginItem>
-            </Tooltip>
-          )}
-        </S.LoginSection>
-
-        {/* <LargeScreenProfileDropdown /> */}
       </S.OverflowContainChild>
     </S.Sidebar>
   );

--- a/src/components/sidebar-navigation/Sidebar.tsx
+++ b/src/components/sidebar-navigation/Sidebar.tsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router';
 
 import { Tooltip } from '../lib/Tooltip';
 import NearIconSvg from './icons/near-icon.svg';
+import { LargeScreenProfileDropdown } from './LargeScreenProfileDropdown';
+import { Search } from './Search';
 import { useNavigationStore } from './store';
 import * as S from './styles';
 import { currentPathMatchesRoute } from './utils';
@@ -37,6 +39,13 @@ export const Sidebar = () => {
             <i className={`ph-bold ${isSidebarExpanded ? 'ph-arrow-line-left' : 'ph-list'}`} />
           </S.ToggleExpandButton>
         </S.Top>
+
+        <S.SearchSection $expanded={isSidebarExpanded}>
+          <Search />
+          <S.SearchIconWrapper $expanded={isSidebarExpanded}>
+            <i className="ph-bold ph-magnifying-glass" />
+          </S.SearchIconWrapper>
+        </S.SearchSection>
 
         <S.Section>
           <S.Stack $gap="0.5rem">
@@ -147,6 +156,10 @@ export const Sidebar = () => {
             </Tooltip>
           </S.Stack>
         </S.Section>
+
+        <S.ProfileDropdownSection $expanded={isSidebarExpanded}>
+          <LargeScreenProfileDropdown />
+        </S.ProfileDropdownSection>
       </S.OverflowContainChild>
     </S.Sidebar>
   );

--- a/src/components/sidebar-navigation/Sidebar.tsx
+++ b/src/components/sidebar-navigation/Sidebar.tsx
@@ -1,6 +1,9 @@
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 
+import { useSignInRedirect } from '@/hooks/useSignInRedirect';
+import { useAuthStore } from '@/stores/auth';
+
 import { Tooltip } from '../lib/Tooltip';
 import NearIconSvg from './icons/near-icon.svg';
 import { LargeScreenProfileDropdown } from './LargeScreenProfileDropdown';
@@ -17,6 +20,14 @@ export const Sidebar = () => {
   const toggleExpandedSidebar = useNavigationStore((store) => store.toggleExpandedSidebar);
   const handleBubbledClickInSidebar = useNavigationStore((store) => store.handleBubbledClickInSidebar);
   const tooltipsDisabled = isSidebarExpanded;
+  const signedIn = useAuthStore((store) => store.signedIn);
+  const { requestAuthentication } = useSignInRedirect();
+
+  const handleCreateAccount = () => {
+    requestAuthentication(true);
+  };
+
+  console.log('signedIn: ', signedIn);
 
   const isNavigationItemActive = (route: string | string[], exactMatch = false) => {
     if (expandedDrawer) return false;
@@ -158,7 +169,16 @@ export const Sidebar = () => {
         </S.Section>
 
         <S.ProfileDropdownSection $expanded={isSidebarExpanded}>
-          <LargeScreenProfileDropdown />
+          {signedIn ? (
+            <LargeScreenProfileDropdown />
+          ) : (
+            <Tooltip content="Sign-up or Login" side="right" disabled={tooltipsDisabled}>
+              <S.LoginItem $active={false} $type="featured" onClick={handleCreateAccount}>
+                <i className="ph-bold ph-user" />
+                <span>Sign-up or Login</span>
+              </S.LoginItem>
+            </Tooltip>
+          )}
         </S.ProfileDropdownSection>
       </S.OverflowContainChild>
     </S.Sidebar>

--- a/src/components/sidebar-navigation/SmallScreenHeader.tsx
+++ b/src/components/sidebar-navigation/SmallScreenHeader.tsx
@@ -1,17 +1,14 @@
 import Image from 'next/image';
-import { useCallback } from 'react';
 
 import { useBosComponents } from '@/hooks/useBosComponents';
 import { useSignInRedirect } from '@/hooks/useSignInRedirect';
 import { useAuthStore } from '@/stores/auth';
-import { useVmStore } from '@/stores/vm';
 
 import { Button } from '../lib/Button';
-import { VmComponent } from '../vm/VmComponent';
 import NearIconSvg from './icons/near-icon.svg';
+import { LargeScreenProfileDropdown } from './LargeScreenProfileDropdown';
 import { useNavigationStore } from './store';
 import * as S from './styles';
-import { LargeScreenProfileDropdown } from './LargeScreenProfileDropdown';
 
 export const SmallScreenHeader = () => {
   const components = useBosComponents();
@@ -20,25 +17,12 @@ export const SmallScreenHeader = () => {
   const setNavigation = useNavigationStore((store) => store.set);
   const showDrawerCollapse = useNavigationStore((store) => store.isOpenedOnSmallScreens && !!store.expandedDrawer);
   const expandedDrawerTitle = useNavigationStore((store) => store.expandedDrawerTitle);
-
-  const near = useVmStore((store) => store.near);
-  const availableStorage = useAuthStore((store) => store.availableStorage);
-  const availableStorageDisplay = availableStorage?.gte(10) ? availableStorage.div(1000).toFixed(2) : '0';
-  const logOut = useAuthStore((store) => store.logOut);
   const signedIn = useAuthStore((store) => store.signedIn);
   const { requestAuthentication } = useSignInRedirect();
 
-  const handleSignIn = () => {
-    requestAuthentication();
-  };
   const handleCreateAccount = () => {
     requestAuthentication(true);
   };
-
-  const withdrawTokens = useCallback(async () => {
-    if (!near) return;
-    await near.contract.storage_withdraw({}, undefined, '1');
-  }, [near]);
 
   return (
     <S.SmallScreenHeader>
@@ -65,14 +49,9 @@ export const SmallScreenHeader = () => {
       )}
 
       {signedIn ? (
-        <S.SmallScreenHeaderActions $hidden={isOpenedOnSmallScreens}>
+        <S.SmallScreenHeaderActions $hidden={isOpenedOnSmallScreens} $gap="16px">
+          <Button label="search" icon="ph ph-magnifying-glass" variant="secondary" href={components.search.indexPage} />
           <LargeScreenProfileDropdown />
-
-          {/* <VmComponent
-            showLoadingSpinner={false}
-            src={components.navigation.smallScreenHeader}
-            props={{ availableStorage: availableStorageDisplay, withdrawTokens, logOut }}
-          /> */}
         </S.SmallScreenHeaderActions>
       ) : (
         <>

--- a/src/components/sidebar-navigation/styles.ts
+++ b/src/components/sidebar-navigation/styles.ts
@@ -231,7 +231,7 @@ export const LoginItem = styled.button<{
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--violet11);
+  color: var(--sand11);
   font-size: 0.875rem;
   line-height: 1.2;
   letter-spacing: 0.28px;
@@ -241,10 +241,10 @@ export const LoginItem = styled.button<{
   transition: all 150ms;
 
   &:hover {
-    color: var(--violet12);
+    color: var(--sand12);
 
     i {
-      background: var(--violet3);
+      background: var(--sand3);
     }
 
     ${NavigationItemThumbnail} {
@@ -262,13 +262,13 @@ export const LoginItem = styled.button<{
 
   i {
     --outline-width: 1px;
-    --outline-color: var(--violet8);
+    --outline-color: var(--sand6);
     outline: var(--outline-width) solid var(--outline-color);
     outline-offset: calc(var(--outline-width) * -1);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--violet8);
+    color: currentColor;
     font-size: 1.25rem;
     border-radius: 4px;
     width: 2.25rem;
@@ -282,6 +282,7 @@ export const LoginItem = styled.button<{
     overflow: hidden;
     text-overflow: ellipsis;
     transition: all var(--sidebar-expand-transition-speed);
+    font-weight: 600;
   }
 
   ${(p) =>

--- a/src/components/sidebar-navigation/styles.ts
+++ b/src/components/sidebar-navigation/styles.ts
@@ -657,13 +657,23 @@ export const LargeScreenHeader = styled.header<{
   }
 `;
 
-export const LargeScreenHeaderActionWrapper = styled.div`
+export const LargeScreenHeaderActionWrapper = styled.div<{
+  $width?: string;
+  $alignItems?: string;
+  $justifyContent?: string;
+}>`
   margin-left: -2px;
   display: flex;
   height: 40px;
-  width: 40px;
-  align-items: center;
-  justify-content: center;
+  width: ${(p) => p.$width ?? '40px'};
+  align-items: ${(p) => p.$alignItems ?? 'center'};
+  justify-content: ${(p) => p.$justifyContent ?? 'center'};
+
+  @media (max-width: ${SMALL_SCREEN_LAYOUT_MAX_WIDTH}px) {
+    .profile-dropdown-name {
+      display: none;
+    }
+  }
 `;
 
 export const LargeScreenHeaderNameWrapper = styled.div`
@@ -870,5 +880,129 @@ export const Drawer = styled.div<{
             width: 0;
             opacity: 0;
           `}
+  }
+`;
+
+export const ProfileDropdownSection = styled(Section)<{
+  $expanded: boolean;
+}>`
+  @media (min-width: ${SMALL_SCREEN_LAYOUT_MAX_WIDTH}px) {
+    ${(p) =>
+      p.$expanded
+        ? css`
+            .profile-dropdown-name {
+              visibility: visible;
+            }
+          `
+        : css`
+            .profile-dropdown-name {
+              visibility: hidden;
+            }
+          `}
+  }
+  @media (max-width: ${SMALL_SCREEN_LAYOUT_MAX_WIDTH}px) {
+    display: none;
+  }
+`;
+
+export const SearchSection = styled(Section)<{
+  $expanded: boolean;
+}>`
+  @media (min-width: ${SMALL_SCREEN_LAYOUT_MAX_WIDTH}px) {
+    ${(p) =>
+      p.$expanded
+        ? css`
+            ${SearchIconWrapper} {
+              display: none;
+            }
+            ${SearchWrapper} {
+              display: block;
+            }
+          `
+        : css`
+            ${SearchIconWrapper} {
+              display: block;
+            }
+            ${SearchWrapper} {
+              display: none;
+            }
+          `}
+  }
+  @media (max-width: ${SMALL_SCREEN_LAYOUT_MAX_WIDTH}px) {
+    display: none;
+  }
+`;
+
+export const SearchWrapper = styled.div`
+  width: 100%;
+  height: 40px;
+
+  > div,
+  > div > label,
+  > div > label > div {
+    height: 100%;
+  }
+`;
+
+export const SearchIconWrapper = styled.div<{
+  $expanded: boolean;
+}>`
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--sand11);
+  font-size: 0.875rem;
+  line-height: 1.2;
+  letter-spacing: 0.28px;
+  text-decoration: none !important;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 150ms;
+
+  &:hover {
+    color: var(--sand12);
+
+    i {
+      background: var(--sand3);
+    }
+  }
+
+  &:focus-visible {
+    i {
+      --outline-color: var(--violet5);
+      --outline-width: 2px;
+    }
+  }
+
+  i {
+    --outline-width: 1px;
+    --outline-color: var(--sand6);
+    outline: var(--outline-width) solid var(--outline-color);
+    outline-offset: calc(var(--outline-width) * -1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: currentColor;
+    font-size: 1.25rem;
+    border-radius: 4px;
+    width: 2.25rem;
+    height: 2.25rem;
+    flex-shrink: 0;
+    background: var(--white);
+    transition: all 150ms, outline 0ms;
+  }
+
+  ${(p) =>
+    p.$expanded
+      ? css`
+          // font-weight: 600;
+          // color: var(--sand12);
+          i {
+            // --outline-color: var(--sand12) !important;
+            // --outline-width: 2px;
+          }
+        `
+      : undefined}
   }
 `;

--- a/src/components/sidebar-navigation/styles.ts
+++ b/src/components/sidebar-navigation/styles.ts
@@ -758,12 +758,14 @@ export const SmallScreenHeaderTitle = styled.p`
 
 export const SmallScreenHeaderActions = styled.div<{
   $hidden: boolean;
+  $gap?: string;
 }>`
   display: flex;
   align-items: center;
   height: 100%;
   opacity: 1;
   transition: all var(--sidebar-expand-transition-speed);
+  gap: ${(p) => p.$gap ?? 'unset'};
 
   ${(p) =>
     p.$hidden


### PR DESCRIPTION
Like I said in this [PR](https://github.com/near/near-discovery-components/pull/836), we decided to 


> Bring the top navbar back along with search (this is the part 2 on the near-discovery side);

In this PR I brought top bar back along with ProfileDropdown.

Relates to https://github.com/near/near-discovery/issues/1196.

Feel free to ask any questions you have!