### PR TITLE
Remove Zendesk widget in favor of Gleap (2 of 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ NEXT_PUBLIC_COMMIT_MODAL_BYPASS_SOURCES=
 # sidebar or marketing layout
 NEXT_PUBLIC_SIDEBAR_LAYOUT=true
 NEXT_PUBLIC_IDOS_CREATE_ACCOUNT_URL="https://app.fractal.id/authorize?client_id=PXAbBxPErSPMXiKmMYQ3ged8Qxwqg1Px7ymhsuhaGP4&redirect_uri=https%3A%2F%2Fdev.near.org%2Fsettings&response_type=code&scope=contact%3Aread%20verification.uniqueness%3Aread%20verification.uniqueness.details%3Aread%20verification.idos%3Aread%20verification.idos.details%3Aread%20verification.wallet-near%3Aread%20verification.wallet-near.details%3Aread"
+# gleap support
+NEXT_PUBLIC_GLEAP_SDK_TOKEN=

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "classnames": "^2.5.1",
     "dompurify": "^3.1.0",
     "firebase": "^9.23.0",
+    "gleap": "^13.7.6",
     "iframe-resizer-react": "^1.1.0",
     "local-storage": "^2.0.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       firebase:
         specifier: ^9.23.0
         version: 9.23.0
+      gleap:
+        specifier: ^13.7.6
+        version: 13.7.6
       iframe-resizer-react:
         specifier: ^1.1.0
         version: 1.1.0(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -5492,6 +5495,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  gleap@13.7.6:
+    resolution: {integrity: sha512-+0oiyIu43QOauxMykBJl3zJFn07uP29HnBrLdkSBTjmh/C7JN46/R0YpteGrBzFM3xHo8ZPvuhx4UWxmclocaw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -6959,6 +6965,9 @@ packages:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
 
+  pick-dom-element@0.2.3:
+    resolution: {integrity: sha512-XBwCZMMnmZAU68lvizuAluOBpImiE3sgXEbrMjBBJ/SjUiHTeep38oiBL8wWMy9ZXxNk6JvmYRUmGiZnCOvUFw==}
+
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -8264,6 +8273,9 @@ packages:
 
   unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+
+  unique-selector@0.5.0:
+    resolution: {integrity: sha512-2KCiRgM19ol67lO493tF7mnQPDuYzwRM7JXrVx336+BPXqT2ccCbUOQQpErFbSc8VIdifLf5x34x4lIeebk+YA==}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -16428,6 +16440,12 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
+  gleap@13.7.6:
+    dependencies:
+      '@floating-ui/dom': 1.6.3
+      pick-dom-element: 0.2.3
+      unique-selector: 0.5.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -18250,6 +18268,8 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
+  pick-dom-element@0.2.3: {}
+
   picocolors@1.0.0: {}
 
   picomatch@2.3.1: {}
@@ -19745,6 +19765,8 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 5.3.7
+
+  unique-selector@0.5.0: {}
 
   unique-string@2.0.0:
     dependencies:

--- a/src/components/vm/VmInitializer.tsx
+++ b/src/components/vm/VmInitializer.tsx
@@ -252,7 +252,6 @@ export default function VmInitializer() {
     setSignedAccountId(null);
     resetAnalytics();
     resetNavigation();
-    localStorage.removeItem('accountId');
   }, [idosSDK, near, resetNavigation]);
 
   const refreshAllowance = useCallback(async () => {

--- a/src/pages/documentation/[[...slug]].tsx
+++ b/src/pages/documentation/[[...slug]].tsx
@@ -1,7 +1,8 @@
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+
 import { useDefaultLayout } from '@/hooks/useLayout';
 import type { NextPageWithLayout } from '@/utils/types';
-import { useRouter } from 'next/router';
 
 const Documentation: NextPageWithLayout = () => {
   const router = useRouter();

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -68,6 +68,7 @@ export const eventsApiUrl = process.env.NEXT_PUBLIC_EVENTS_API_URL;
 export const eventsApiKey = process.env.NEXT_PUBLIC_EVENTS_API_KEY;
 export const sidebarLayoutEnabled = process.env.NEXT_PUBLIC_SIDEBAR_LAYOUT === 'true';
 export const idosCreateAccountUrl = process.env.NEXT_PUBLIC_IDOS_CREATE_ACCOUNT_URL;
+export const gleapSdkToken = process.env.NEXT_PUBLIC_GLEAP_SDK_TOKEN;
 
 export const commitModalBypassAuthorIds = (process.env.NEXT_PUBLIC_COMMIT_MODAL_BYPASS_AUTHOR_IDS ?? '')
   .split(',')


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery/issues/1223

Removed existing Zendesk widget and added Gleap support widget to `dev.near.org`. We'll need to update the background image in the Gleap dashboard - left a comment here: https://github.com/near/near-discovery/issues/1223#issuecomment-2214816050

Environment variables have been set in Vercel.