### PR TITLE
fix: update nearcatalog url

### DIFF
--- a/src/utils/catalogSearchApi.ts
+++ b/src/utils/catalogSearchApi.ts
@@ -1,4 +1,4 @@
 export const fetchCatalog = async (query: string) => {
-  const response = await fetch(`https://nearcatalog.xyz/wp-json/nearcatalog/v1/search?kw=${query}`);
+  const response = await fetch(`https://indexer.nearcatalog.xyz/wp-json/nearcatalog/v1/search?kw=${query}`);
   return await response.json();
 };


### PR DESCRIPTION
The nearcatalog.xyz redesign moved their search endpoint to a new URL.