### PR TITLE
Expose `setURLSearchParams` and `scrollTo` functions to Applications page (NEAR Catalog component)

### DIFF
--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -15,6 +15,12 @@ const ApplicationsPage: NextPageWithLayout = () => {
   const authStore = useAuthStore();
   const accountId = authStore.accountId;
 
+  const changeUrl = (newUrl: string) => {
+    if (window.location.pathname !== newUrl) {
+      window.history.pushState({}, '', newUrl);
+    }
+  }
+
   useEffect(() => {
     const { requestAuth, createAccount } = router.query;
     if (requestAuth && !accountId) {
@@ -26,6 +32,9 @@ const ApplicationsPage: NextPageWithLayout = () => {
     <ComponentWrapperPage
       src={components.applicationsPage}
       meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
+      componentProps={{
+        changeUrl
+      }}
     />
   );
 };

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -19,15 +19,15 @@ const ApplicationsPage: NextPageWithLayout = () => {
     if (!params) return;
     const searchParams = new URLSearchParams(params);
     if (searchParams.toString().length > 0) {
-      window.history.pushState({}, '', "?" + searchParams.toString());
+      window.history.pushState({}, '', '?' + searchParams.toString());
     } else {
       window.history.pushState({}, '', window.location.pathname);
     }
-  }
+  };
 
   const scrollTo = (options: ScrollToOptions | undefined) => {
     window.scrollTo(options);
-  }
+  };
 
   useEffect(() => {
     const { requestAuth, createAccount } = router.query;

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -37,7 +37,8 @@ const ApplicationsPage: NextPageWithLayout = () => {
       src={components.applicationsPage}
       meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
       componentProps={{
-        setURLSearchParams
+        setURLSearchParams,
+        scrollTo: window.scrollTo,
       }}
     />
   );

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -17,7 +17,7 @@ const ApplicationsPage: NextPageWithLayout = () => {
 
   const setURLSearchParams = (params: string | string[][] | Record<string, string> | URLSearchParams | undefined) => {
     if (!params) return;
-    let searchParams = new URLSearchParams(params);
+    const searchParams = new URLSearchParams(params);
     if (searchParams.toString().length > 0) {
       window.history.pushState({}, '', "?" + searchParams.toString());
     } else {

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -25,7 +25,9 @@ const ApplicationsPage: NextPageWithLayout = () => {
     }
   }
 
-  const scrollTo = window.scrollTo;
+  const scrollTo = (options: ScrollToOptions | undefined) => {
+    window.scrollTo(options);
+  }
 
   useEffect(() => {
     const { requestAuth, createAccount } = router.query;

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -25,6 +25,8 @@ const ApplicationsPage: NextPageWithLayout = () => {
     }
   }
 
+  const scrollTo = window.scrollTo;
+
   useEffect(() => {
     const { requestAuth, createAccount } = router.query;
     if (requestAuth && !accountId) {
@@ -38,7 +40,7 @@ const ApplicationsPage: NextPageWithLayout = () => {
       meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
       componentProps={{
         setURLSearchParams,
-        scrollTo: window.scrollTo,
+        scrollTo,
       }}
     />
   );

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -15,9 +15,13 @@ const ApplicationsPage: NextPageWithLayout = () => {
   const authStore = useAuthStore();
   const accountId = authStore.accountId;
 
-  const changeUrl = (newUrl: string) => {
-    if (window.location.pathname !== newUrl) {
-      window.history.pushState({}, '', newUrl);
+  const setURLSearchParams = (params: string | string[][] | Record<string, string> | URLSearchParams | undefined) => {
+    if (!params) return;
+    let searchParams = new URLSearchParams(params);
+    if (searchParams.toString().length > 0) {
+      window.history.pushState({}, '', "?" + searchParams.toString());
+    } else {
+      window.history.pushState({}, '', window.location.pathname);
     }
   }
 
@@ -33,7 +37,7 @@ const ApplicationsPage: NextPageWithLayout = () => {
       src={components.applicationsPage}
       meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
       componentProps={{
-        changeUrl
+        setURLSearchParams
       }}
     />
   );


### PR DESCRIPTION
Since NEAR Catalog, the BOS component behind the Applications page (https://dev.near.org/applications), is migrating to a new version (https://nearcatalog.xyz/) built with React, we need to update the BOS component source code with an embedded iframe that renders the https://nearcatalog.xyz/ page inside the component. 

To make sure the URL query parameters are updated properly after clicking links inside the iframe, we'd like to expose the `setURLSearchParams` function to the `nearcatalog.near/widget/Index` component. For example, when user clicks on Ref Finance project, the URL should be updated to `https://dev.near.org/application?id=ref-finance`. But BOS VM doesn't allow updating URL query parameters programmatically, so we propose to add an additional function at gateway level.

For better navigation inside the page, we also need the `scrollTo` function to be accessible in the `nearcatalog.near/widget/Index` component.

