### PR TITLE
fix: broken styles for firefox in wallet utilities

### DIFF
--- a/src/components/wallet-utilities/KeyTable.tsx
+++ b/src/components/wallet-utilities/KeyTable.tsx
@@ -87,14 +87,14 @@ const KeyTable: React.FC = () => {
               </Table.Cell>
               <Table.Cell>
                 <Tooltip content={data.access_key.permission.FunctionCall?.receiver_id ?? 'N/A'}>
-                  <Text style={{ minWidth: '5rem', whiteSpace:"pre-wrap" }} clampLines={1}>
+                  <Text style={{ minWidth: '5rem', whiteSpace: 'pre-wrap' }} clampLines={1}>
                     {data.access_key.permission.FunctionCall?.receiver_id ?? 'N/A'}
                   </Text>
                 </Tooltip>
               </Table.Cell>
               <Table.Cell>
                 <Tooltip content={data.public_key}>
-                  <Text style={{ minWidth: '5rem', whiteSpace:"pre-wrap" }} clampLines={1}>
+                  <Text style={{ minWidth: '5rem', whiteSpace: 'pre-wrap' }} clampLines={1}>
                     {data.public_key}
                   </Text>
                 </Tooltip>

--- a/src/components/wallet-utilities/KeyTable.tsx
+++ b/src/components/wallet-utilities/KeyTable.tsx
@@ -87,14 +87,14 @@ const KeyTable: React.FC = () => {
               </Table.Cell>
               <Table.Cell>
                 <Tooltip content={data.access_key.permission.FunctionCall?.receiver_id ?? 'N/A'}>
-                  <Text style={{ minWidth: '5rem' }} clampLines={1}>
+                  <Text style={{ minWidth: '5rem', whiteSpace:"pre-wrap" }} clampLines={1}>
                     {data.access_key.permission.FunctionCall?.receiver_id ?? 'N/A'}
                   </Text>
                 </Tooltip>
               </Table.Cell>
               <Table.Cell>
                 <Tooltip content={data.public_key}>
-                  <Text style={{ minWidth: '5rem' }} clampLines={1}>
+                  <Text style={{ minWidth: '5rem', whiteSpace:"pre-wrap" }} clampLines={1}>
                     {data.public_key}
                   </Text>
                 </Tooltip>


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/afe919ff-bf2e-4c2e-b297-db1c45bb0cf3)
after:
![image](https://github.com/user-attachments/assets/a0314be1-ff28-426f-a6a8-8d271be77652)

