### PR TITLE
fix: import router query as component props in applications page

### DIFF
--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -40,6 +40,7 @@ const ApplicationsPage: NextPageWithLayout = () => {
       src={components.applicationsPage}
       meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
       componentProps={{
+        targetProps: router.query,
         setURLSearchParams,
         scrollTo,
       }}

--- a/src/pages/applications.tsx
+++ b/src/pages/applications.tsx
@@ -40,7 +40,7 @@ const ApplicationsPage: NextPageWithLayout = () => {
       src={components.applicationsPage}
       meta={{ title: 'NEAR | Applications', description: 'Featured applications built on NEAR' }}
       componentProps={{
-        targetProps: router.query,
+        ...router.query,
         setURLSearchParams,
         scrollTo,
       }}


### PR DESCRIPTION
As mentioned in PR #1301, we'd like to update URL query parameters from NEAR Catalog component. 

But we cannot read the URL query parameters as `props` in NEAR Catalog component under the `applications` router. This PR fixes this issue. 