### PR TITLE
fix: correct API endpoint for searching NEARCatalog db

### DIFF
--- a/src/utils/catalogSearchApi.ts
+++ b/src/utils/catalogSearchApi.ts
@@ -1,6 +1,6 @@
 export const fetchCatalog = async (query: string) => {
   try {
-    const response = await fetch(`https://indexer.nearcatalog.xyz/wp-json/nearcatalog/v1/search?kw=${query}`);
+    const response = await fetch(`https://api.nearcatalog.org/search?kw=${query}`);
     return await response.json();
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
The previous API endpoint of dev.near.org to querying NearCatalog DB (https://indexer.nearcatalog.xyz/)  is not designed for public usage, only for NEARCatalog frontends, thus leads to dev.near.org/search not working.

I changed to the correct public API endpoint of NEARCatalog: https://api.nearcatalog.org/ according to the API docs: https://docs.nearcatalog.org/ 